### PR TITLE
fix electron-builder appID

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -1,5 +1,5 @@
 {
-  appId: "YourAppID",
+  appId: "org.reorproject.reor",
   asar: true,
   directories: {
     output: "release/${version}",


### PR DESCRIPTION
While packaging reor for homebrew-cask, I found the appID is wrong, thus fixing it.

relates to https://github.com/Homebrew/homebrew-cask/pull/167053