### PR TITLE
add files based content prompting

### DIFF
--- a/electron/main/Files/Types.ts
+++ b/electron/main/Files/Types.ts
@@ -15,3 +15,9 @@ export type FileInfoTree = FileInfoNode[];
 export const isFileNodeDirectory = (fileInfo: FileInfoNode): boolean => {
   return fileInfo.children !== undefined;
 };
+
+export interface AugmentPromptWithFileProps {
+  prompt: string;
+  llmSessionID: string;
+  filePath: string;
+}

--- a/electron/main/Files/registerFilesHandler.ts
+++ b/electron/main/Files/registerFilesHandler.ts
@@ -15,7 +15,7 @@ import {
 } from "../windowManager";
 import { errorToString } from "../Generic/error";
 import { LLMSessions } from "../llm/llmSessionHandlers";
-import { createFilePrompt, createRAGPrompt } from "../Prompts/Prompts";
+import { createFilePrompt } from "../Prompts/Prompts";
 
 export const registerFileHandlers = () => {
   ipcMain.handle("join-path", (event, ...args) => {

--- a/electron/main/Files/registerFilesHandler.ts
+++ b/electron/main/Files/registerFilesHandler.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from "electron";
 import * as path from "path";
-import { FileInfoTree } from "./Types";
+import { FileInfoTree, AugmentPromptWithFileProps } from "./Types";
 import {
   GetFilesInfoTree,
   orchestrateEntryMove,
@@ -120,9 +120,7 @@ export const registerFileHandlers = () => {
     "augment-prompt-with-file",
     async (
       event,
-      query: string,
-      llmSessionID: string,
-      filePath: string
+     { prompt, llmSessionID, filePath }: AugmentPromptWithFileProps
     ): Promise<string> => {
       try {
         const windowInfo = getWindowInfoForContents(
@@ -141,7 +139,7 @@ export const registerFileHandlers = () => {
 
         const filePrompt = createFilePrompt(
           content,
-          query,
+          prompt,
           llmSession.tokenize,
           llmSession.getContextLength()
         );

--- a/electron/main/Prompts/Prompts.ts
+++ b/electron/main/Prompts/Prompts.ts
@@ -1,5 +1,3 @@
-import { file } from "tmp";
-import { chunkMarkdownByHeadingsAndByCharsIfBig } from "../RAG/Chunking";
 import { DBEntry } from "../database/Schema";
 
 

--- a/electron/main/Prompts/Prompts.ts
+++ b/electron/main/Prompts/Prompts.ts
@@ -42,12 +42,10 @@ export function createFilePrompt(
   tokenize: (text: string) => number[],
   contextLimit: number
 ): string {
-  let entryContents = "";
-
   const basePrompt = `Answer the question below based on the following notes:\n ${content}\n`;
   const queryPrompt = `Question: ${query}`;
 
-  let tokenCount = tokenize(basePrompt + queryPrompt).length;
+  const tokenCount = tokenize(basePrompt + queryPrompt).length;
 
   if (tokenCount >= contextLimit) {
     throw new Error(
@@ -55,7 +53,7 @@ export function createFilePrompt(
     );
   }
 
-  const output = basePrompt + entryContents + queryPrompt;
+  const output = basePrompt + queryPrompt;
   return output;
 }
 

--- a/electron/main/Prompts/Prompts.ts
+++ b/electron/main/Prompts/Prompts.ts
@@ -33,3 +33,29 @@ export function createRAGPrompt(
   const output = basePrompt + entryContents + queryPrompt;
   return output;
 }
+
+
+
+export function createFilePrompt(
+  content: string,
+  query: string,
+  tokenize: (text: string) => number[],
+  contextLimit: number
+): string {
+  let entryContents = "";
+
+  const basePrompt = `Answer the question below based on the following notes:\n ${content}\n`;
+  const queryPrompt = `Question: ${query}`;
+
+  let tokenCount = tokenize(basePrompt + queryPrompt).length;
+
+  if (tokenCount >= contextLimit) {
+    throw new Error(
+      "The provided information is too long to process in a single prompt. Please shorten the query or provide fewer details."
+    );
+  }
+
+  const output = basePrompt + entryContents + queryPrompt;
+  return output;
+}
+

--- a/electron/main/Prompts/Prompts.ts
+++ b/electron/main/Prompts/Prompts.ts
@@ -1,5 +1,9 @@
+import { file } from "tmp";
+import { chunkMarkdownByHeadingsAndByCharsIfBig } from "../RAG/Chunking";
 import { DBEntry } from "../database/Schema";
 
+
+const TOKEN_LIMIT_MESSAGE = "The provided information is too long to process in a single prompt. Please shorten the query or provide fewer details."
 export function createRAGPrompt(
   entries: DBEntry[],
   query: string,
@@ -25,9 +29,7 @@ export function createRAGPrompt(
   }
 
   if (tokenCount >= contextLimit) {
-    throw new Error(
-      "The provided information is too long to process in a single prompt. Please shorten the query or provide fewer details."
-    );
+    throw new Error(TOKEN_LIMIT_MESSAGE);
   }
 
   const output = basePrompt + entryContents + queryPrompt;
@@ -49,7 +51,7 @@ export function createFilePrompt(
 
   if (tokenCount >= contextLimit) {
     throw new Error(
-      "The provided information is too long to process in a single prompt. Please shorten the query or provide fewer details."
+      `The provided information is too long to process in a single prompt. Please shorten the query or provide fewer details. Current token count: ${tokenCount}, Limit: ${contextLimit}`
     );
   }
 

--- a/electron/main/Prompts/Prompts.ts
+++ b/electron/main/Prompts/Prompts.ts
@@ -1,59 +1,38 @@
 import { DBEntry } from "../database/Schema";
-
-
-const TOKEN_LIMIT_MESSAGE = "The provided information is too long to process in a single prompt. Please shorten the query or provide fewer details."
-export function createRAGPrompt(
-  entries: DBEntry[],
-  query: string,
-  tokenize: (text: string) => number[],
-  contextLimit: number
-): string {
-  let entryContents = "";
-
-  const basePrompt = `Answer the question below based on the following notes:\n`;
-  const queryPrompt = `Question: ${query}`;
-
-  let tokenCount = tokenize(basePrompt + queryPrompt).length;
-  for (const entry of entries) {
-    const tempEntryContent = `${entryContents}${entry.content}\n`;
-    const tempPrompt = basePrompt + tempEntryContent + queryPrompt;
-    const tempTokenCount = tokenize(tempPrompt).length;
-    if (tempTokenCount <= contextLimit) {
-      entryContents = tempEntryContent;
-      tokenCount = tempTokenCount;
-    } else {
-      break;
-    }
-  }
-
-  if (tokenCount >= contextLimit) {
-    throw new Error(TOKEN_LIMIT_MESSAGE);
-  }
-
-  const output = basePrompt + entryContents + queryPrompt;
-  return output;
+export interface PromptWithContextLimit {
+  prompt: string;
+  contextCutoffAt?: string;
 }
 
-
-
-export function createFilePrompt(
-  content: string,
+export function createPromptWithContextLimitFromContent(
+  content: string | DBEntry[],
   query: string,
   tokenize: (text: string) => number[],
   contextLimit: number
-): string {
-  const basePrompt = `Answer the question below based on the following notes:\n ${content}\n`;
+): PromptWithContextLimit {
+  const basePrompt = 'Answer the question below based on the following notes:\n ';
   const queryPrompt = `Question: ${query}`;
+  let tokenCount = tokenize(queryPrompt + basePrompt).length;  
 
-  const tokenCount = tokenize(basePrompt + queryPrompt).length;
+  const contentArray: string[] = [] 
+  let cutOffLine: string = '';
+  const contents = ( typeof content === 'string') ? content.split("\n") : content.map(entry => entry.content);
 
-  if (tokenCount >= contextLimit) {
-    throw new Error(
-      `The provided information is too long to process in a single prompt. Please shorten the query or shorten the file. Current token count: ${tokenCount}, Limit: ${contextLimit}`
-    );
-  }
+  for (const line of contents) {
+    const lineWithNewLine = line + "\n";
+    if ((tokenize(lineWithNewLine).length + tokenCount) < contextLimit) {
+      tokenCount += tokenize(lineWithNewLine).length;
+      contentArray.push(lineWithNewLine);
+    } else if (cutOffLine.length === 0) {
+      cutOffLine = lineWithNewLine;
+    }
+  }  
+  
+  const outputPrompt = basePrompt + contentArray.join("") + queryPrompt;
 
-  const output = basePrompt + queryPrompt;
-  return output;
+  return {
+    prompt: outputPrompt, 
+    contextCutoffAt: cutOffLine || undefined
+  };
 }
 

--- a/electron/main/Prompts/Prompts.ts
+++ b/electron/main/Prompts/Prompts.ts
@@ -51,7 +51,7 @@ export function createFilePrompt(
 
   if (tokenCount >= contextLimit) {
     throw new Error(
-      `The provided information is too long to process in a single prompt. Please shorten the query or provide fewer details. Current token count: ${tokenCount}, Limit: ${contextLimit}`
+      `The provided information is too long to process in a single prompt. Please shorten the query or shorten the file. Current token count: ${tokenCount}, Limit: ${contextLimit}`
     );
   }
 

--- a/electron/main/database/dbSessionHandlers.ts
+++ b/electron/main/database/dbSessionHandlers.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from "electron";
-import { createRAGPrompt } from "../Prompts/Prompts";
+import { createPromptWithContextLimitFromContent } from "../Prompts/Prompts";
 import { DBEntry, DatabaseFields } from "./Schema";
 import { LLMSessions } from "../llm/llmSessionHandlers";
 import { StoreKeys, StoreSchema } from "../Store/storeConfig";
@@ -73,7 +73,7 @@ export const registerDBSessionHandlers = (
           throw new Error(`Session ${llmSessionID} does not exist.`);
         }
 
-        const ragPrompt = createRAGPrompt(
+        const { prompt: ragPrompt } = createPromptWithContextLimitFromContent(
           searchResults,
           query,
           llmSession.tokenize,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -6,7 +6,7 @@ import {
   HardwareConfig,
   LLMModelConfig,
 } from "electron/main/Store/storeConfig";
-import { FileInfoNode, FileInfoTree } from "electron/main/Files/Types";
+import { AugmentPromptWithFileProps, FileInfoNode, FileInfoTree } from "electron/main/Files/Types";
 import { DBEntry, DBQueryResult } from "electron/main/database/Schema";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ReceiveCallback = (...args: any[]) => void;
@@ -54,9 +54,7 @@ declare global {
         destinationPath: string
       ) => Promise<void>;
       augmentPromptWithFile: (
-        prompt: string,
-        llmSessionID: string,
-        filePath: string
+        augmentPromptWithFileProps: AugmentPromptWithFileProps
       ) => Promise<string>;
     };
     path: {
@@ -254,16 +252,9 @@ contextBridge.exposeInMainWorld("files", {
     return ipcRenderer.invoke("move-file-or-dir", sourcePath, destinationPath);
   },
   augmentPromptWithFile: async (
-    prompt: string,
-    llmSessionID: string,
-    filePath: string
+    augmentPromptWithFileProps : AugmentPromptWithFileProps
   ): Promise<string> => {
-    return ipcRenderer.invoke(
-      "augment-prompt-with-file",
-      prompt,
-      llmSessionID,
-      filePath
-    );
+    return ipcRenderer.invoke("augment-prompt-with-file", augmentPromptWithFileProps);
   },
 });
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -53,6 +53,11 @@ declare global {
         sourcePath: string,
         destinationPath: string
       ) => Promise<void>;
+      augmentPromptWithFile: (
+        prompt: string,
+        llmSessionID: string,
+        filePath: string
+      ) => Promise<string>;
     };
     path: {
       basename: (pathString: string) => string;
@@ -247,6 +252,18 @@ contextBridge.exposeInMainWorld("files", {
 
   moveFileOrDir: async (sourcePath: string, destinationPath: string) => {
     return ipcRenderer.invoke("move-file-or-dir", sourcePath, destinationPath);
+  },
+  augmentPromptWithFile: async (
+    prompt: string,
+    llmSessionID: string,
+    filePath: string
+  ): Promise<string> => {
+    return ipcRenderer.invoke(
+      "augment-prompt-with-file",
+      prompt,
+      llmSessionID,
+      filePath
+    );
   },
 });
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -8,6 +8,7 @@ import {
 } from "electron/main/Store/storeConfig";
 import { AugmentPromptWithFileProps, FileInfoNode, FileInfoTree } from "electron/main/Files/Types";
 import { DBEntry, DBQueryResult } from "electron/main/database/Schema";
+import { PromptWithContextLimit } from "electron/main/Prompts/Prompts";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ReceiveCallback = (...args: any[]) => void;
 
@@ -55,7 +56,7 @@ declare global {
       ) => Promise<void>;
       augmentPromptWithFile: (
         augmentPromptWithFileProps: AugmentPromptWithFileProps
-      ) => Promise<string>;
+      ) => Promise<PromptWithContextLimit>;
     };
     path: {
       basename: (pathString: string) => string;
@@ -253,7 +254,7 @@ contextBridge.exposeInMainWorld("files", {
   },
   augmentPromptWithFile: async (
     augmentPromptWithFileProps : AugmentPromptWithFileProps
-  ): Promise<string> => {
+  ): Promise<PromptWithContextLimit> => {
     return ipcRenderer.invoke("augment-prompt-with-file", augmentPromptWithFileProps);
   },
 });

--- a/src/components/Chat/Chat-Prompts.tsx
+++ b/src/components/Chat/Chat-Prompts.tsx
@@ -11,7 +11,7 @@ export const ChatPrompt: FC<Props> = ({ promptText, onClick } : Props) => {
       <button
         className={`
             rounded bg-gray-200 p-5 shadow dark:bg-gray-700 text-white text-base
-            hover:bg-gray-300 hover:text-black
+            hover:bg-gray-300 hover:text-black cursor-pointer
             border-solid border border-white border-opacity-50`}
           onClick={onClick}
       >

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -108,10 +108,11 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({ currentFilePath }) => {
           return;
         }
         augmentedPrompt = await window.files.augmentPromptWithFile(
-          userInput,
-          currentSessionId,
-          currentFilePath
-        );
+          { 
+            prompt: userInput,
+            llmSessionID: currentSessionId,
+            filePath: currentFilePath
+          });
       } else if (askText === AskOptions.Ask){
         augmentedPrompt = await window.database.augmentPromptWithRAG(
           userInput,

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -13,7 +13,6 @@ import CircularProgress from "@mui/material/CircularProgress";
 import ReactMarkdown from "react-markdown";
 import { FiRefreshCw } from "react-icons/fi"; // Importing refresh icon from React Icons
 import { ChatPrompt } from "./Chat-Prompts";
-import { toast } from "react-toastify";
 
 // convert ask options to enum
 enum AskOptions {

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -116,12 +116,16 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({ currentFilePath }) => {
           toast.error("No current file selected. Please open a file before trying again.")
           return;
         }
-        augmentedPrompt = await window.files.augmentPromptWithFile(
+        const { prompt, contextCutoffAt } = await window.files.augmentPromptWithFile(
           { 
             prompt: userInput,
             llmSessionID: currentSessionId,
             filePath: currentFilePath
           });
+        if (contextCutoffAt) {
+          toast.warning(`The file is too large to be used as context. It got cut off at: ${contextCutoffAt}`)
+        }
+        augmentedPrompt = prompt;
       } else if (askText === AskOptions.Ask){
         augmentedPrompt = await window.database.augmentPromptWithRAG(
           userInput,


### PR DESCRIPTION
This PR adds:
- AugmentPrompt with file handler
- Toast errors if a file is not yet selected and if the context is too large
- Removes previous augment prompt context filter and separate the cases

Example warning message (edited so that it doesn't block generating the output, but still not ideal yet)
![image](https://github.com/reorproject/reor/assets/58682208/288d20fe-690d-4bfd-9701-76cde27731bc)

