### PR TITLE
switch to using titpap markdown extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react-switch": "^7.0.0",
         "react-toastify": "^10.0.4",
         "react-window": "^1.8.10",
+        "tiptap-markdown": "^0.8.10",
         "turndown": "^7.1.2",
         "use-debounce": "^10.0.0",
         "vectordb": "0.4.10"
@@ -4367,10 +4368,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw=="
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
+      "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.3",
@@ -4379,6 +4394,11 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA=="
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
@@ -12304,20 +12324,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.0.0.tgz",
-      "integrity": "sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
         "linkify-it": "^5.0.0",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
-        "uc.micro": "^2.0.0"
+        "uc.micro": "^2.1.0"
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA=="
     },
     "node_modules/marked": {
       "version": "12.0.1",
@@ -18855,6 +18880,20 @@
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "dependencies": {
         "@popperjs/core": "^2.9.0"
+      }
+    },
+    "node_modules/tiptap-markdown": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.8.10.tgz",
+      "integrity": "sha512-iDVkR2BjAqkTDtFX0h94yVvE2AihCXlF0Q7RIXSJPRSR5I0PA1TMuAg6FHFpmqTn4tPxJ0by0CK7PUMlnFLGEQ==",
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.3"
       }
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-switch": "^7.0.0",
     "react-toastify": "^10.0.4",
     "react-window": "^1.8.10",
+    "tiptap-markdown": "^0.8.10",
     "turndown": "^7.1.2",
     "use-debounce": "^10.0.0",
     "vectordb": "0.4.10"


### PR DESCRIPTION
- Fixes issue with checkboxes and code blocks being lost after being written to disk and then reopened.
- This now uses tiptap-markdown to deal with markdown in tiptap