### PR TITLE
Improve ollama server setup reliability

### DIFF
--- a/electron/main/Store/storeHandlers.ts
+++ b/electron/main/Store/storeHandlers.ts
@@ -34,7 +34,7 @@ export const registerStoreHandlers = (
   ipcMain.on("get-user-directory", (event) => {
     let path = windowsManager.getVaultDirectoryForWinContents(event.sender);
     if (!path) {
-      path = windowsManager.getAndSetupDirectoryFromPreviousSessionIfUnused(
+      path = windowsManager.getAndSetupDirectoryForWindowFromPreviousAppSession(
         event.sender,
         store
       );

--- a/electron/main/llm/llmSessionHandlers.ts
+++ b/electron/main/llm/llmSessionHandlers.ts
@@ -23,8 +23,6 @@ export const openAISession = new OpenAIModelSessionService();
 export const ollamaService = new OllamaService();
 
 export const registerLLMSessionHandlers = async (store: Store<StoreSchema>) => {
-  await ollamaService.init();
-
   ipcMain.handle(
     "streaming-llm-response",
     async (

--- a/electron/main/llm/llmSessionHandlers.ts
+++ b/electron/main/llm/llmSessionHandlers.ts
@@ -22,7 +22,7 @@ export const openAISession = new OpenAIModelSessionService();
 
 export const ollamaService = new OllamaService();
 
-export const registerLLMSessionHandlers = async (store: Store<StoreSchema>) => {
+export const registerLLMSessionHandlers = (store: Store<StoreSchema>) => {
   ipcMain.handle(
     "streaming-llm-response",
     async (

--- a/electron/main/llm/llmSessionHandlers.ts
+++ b/electron/main/llm/llmSessionHandlers.ts
@@ -58,7 +58,7 @@ export const registerLLMSessionHandlers = (store: Store<StoreSchema>) => {
 
   ipcMain.handle("pull-ollama-model", async (event, modelName: string) => {
     const handleProgress = (progress: ProgressResponse) => {
-      event.sender.send("ollamaDownloadProgress", progress);
+      event.sender.send("ollamaDownloadProgress", modelName, progress);
     };
     await ollamaService.pullModel(modelName, handleProgress);
   });

--- a/electron/main/llm/models/Ollama.ts
+++ b/electron/main/llm/models/Ollama.ts
@@ -66,7 +66,6 @@ export class OllamaService implements LLMSessionService {
       await this.ping();
       return OllamaServeType.SYSTEM;
     } catch (err) {
-      // throw new Error(`Failed to start Ollama: ${err}`);
       // this is fine, we just need to start ollama
     }
 

--- a/electron/main/llm/models/Ollama.ts
+++ b/electron/main/llm/models/Ollama.ts
@@ -82,14 +82,12 @@ export class OllamaService implements LLMSessionService {
 
     let exeName = "";
     let exeDir = "";
-    let appDataPath = "";
     switch (process.platform) {
       case "win32":
         exeName = "ollama.exe";
         exeDir = app.isPackaged
           ? path.join(process.resourcesPath, "binaries")
           : path.join(app.getAppPath(), "binaries", "win32");
-        appDataPath = path.join(os.homedir(), "AppData", "Local", "chatd");
 
         break;
       case "darwin":
@@ -97,19 +95,12 @@ export class OllamaService implements LLMSessionService {
         exeDir = app.isPackaged
           ? path.join(process.resourcesPath, "binaries")
           : path.join(app.getAppPath(), "binaries", "darwin");
-        appDataPath = path.join(
-          os.homedir(),
-          "Library",
-          "Application Support",
-          "chatd"
-        );
         break;
       case "linux":
         exeName = "ollama-linux";
         exeDir = app.isPackaged
           ? path.join(process.resourcesPath, "binaries")
           : path.join(app.getAppPath(), "binaries", "linux");
-        appDataPath = path.join(os.homedir(), ".config", "chatd");
 
         break;
       default:
@@ -117,21 +108,17 @@ export class OllamaService implements LLMSessionService {
     }
     const exePath = path.join(exeDir, exeName);
     try {
-      await this.execServe(exePath, appDataPath);
+      await this.execServe(exePath);
       return OllamaServeType.PACKAGED;
     } catch (err) {
       throw new Error(`Failed to start Ollama: ${err}`);
     }
   }
 
-  async execServe(path: string, appDataDirectory?: string) {
+  async execServe(path: string) {
     return new Promise((resolve, reject) => {
-      if (appDataDirectory && !fs.existsSync(appDataDirectory)) {
-        fs.mkdirSync(appDataDirectory, { recursive: true });
-      }
       const env = {
         ...process.env,
-        OLLAMA_MODELS: appDataDirectory,
       };
       this.childProcess = exec(
         path + " serve",

--- a/electron/main/llm/models/Ollama.ts
+++ b/electron/main/llm/models/Ollama.ts
@@ -178,6 +178,24 @@ export class OllamaService implements LLMSessionService {
     throw new Error("Max retries reached. Ollama server didn't respond.");
   }
 
+  stop() {
+    if (!this.childProcess) {
+      return;
+    }
+
+    if (os.platform() === "win32") {
+      exec(`taskkill /pid ${this.childProcess.pid} /f /t`, (err) => {
+        if (err) {
+          console.log("Failed to kill Ollama process: ", err);
+        }
+      });
+    } else {
+      this.childProcess.kill();
+    }
+    console.log("Ollama process killed");
+    this.childProcess = null;
+  }
+
   public getAvailableModels = async (): Promise<OpenAILLMConfig[]> => {
     const ollamaModelsResponse = await this.client.list();
 

--- a/electron/main/llm/models/Ollama.ts
+++ b/electron/main/llm/models/Ollama.ts
@@ -204,6 +204,7 @@ export class OllamaService implements LLMSessionService {
     modelName: string,
     handleProgress: (chunk: ProgressResponse) => void
   ): Promise<void> => {
+    console.log("Pulling model: ", modelName);
     const stream = await this.client.pull({
       model: modelName,
       stream: true,

--- a/electron/main/windowManager.ts
+++ b/electron/main/windowManager.ts
@@ -11,8 +11,9 @@ type WindowInfo = {
 
 class WindowsManager {
   activeWindows: WindowInfo[] = [];
+  private errorStringsToSendWindow: string[] = [];
 
-  getAndSetupDirectoryFromPreviousSessionIfUnused(
+  getAndSetupDirectoryForWindowFromPreviousAppSession(
     webContents: Electron.WebContents,
     store: Store<StoreSchema>
   ): string {
@@ -34,6 +35,16 @@ class WindowsManager {
       return lastUsedVaultDirectory;
     }
     return "";
+  }
+
+  appendNewErrorToDisplayInWindow(errorString: string) {
+    this.errorStringsToSendWindow.push(errorString);
+  }
+
+  getAndClearErrorStrings(): string[] {
+    const errorStrings = this.errorStringsToSendWindow;
+    this.errorStringsToSendWindow = [];
+    return errorStrings;
   }
 
   getBrowserWindowId(webContents: WebContents): number | null {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,10 @@ const App: React.FC<AppProps> = () => {
       });
       setIndexingProgress(1);
     };
-    window.ipcRenderer.receive("indexing-error", handleIndexingError);
+    window.ipcRenderer.receive(
+      "error-to-display-in-window",
+      handleIndexingError
+    );
   }, []);
 
   useEffect(() => {

--- a/src/components/Settings/ExtraModals/NewOllamaModel.tsx
+++ b/src/components/Settings/ExtraModals/NewOllamaModel.tsx
@@ -10,18 +10,25 @@ interface NewOllamaModelModalProps {
   onClose: () => void;
 }
 
+interface ModelDownloadStatus {
+  progress: ProgressResponse;
+  error?: string; // Optional error message
+}
+
 const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
   isOpen,
   onClose,
 }) => {
   // const [newModelPath, setNewModelPath] = useState<string>("");
   const [modelName, setModelName] = useState("");
-  const [error, setError] = useState("");
-  const [downloadProgress, setDownloadProgress] = useState<ProgressResponse>();
+  const [modelNameerror, setModelNameError] = useState("");
+  const [downloadProgress, setDownloadProgress] = useState<{
+    [modelName: string]: ModelDownloadStatus;
+  }>({});
 
   const downloadSelectedModel = async () => {
     if (!modelName) {
-      setError("Please enter a model name");
+      setModelNameError("Please enter a model name");
       return;
     }
     let taggedModelName = modelName;
@@ -29,19 +36,31 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
       taggedModelName = `${taggedModelName}:latest`;
     }
     try {
-      setError("");
       await window.llm.pullOllamaModel(taggedModelName);
       await window.llm.setDefaultLLM(taggedModelName);
     } catch (e) {
-      setError(errorToString(e));
+      setDownloadProgress((prevProgress) => ({
+        ...prevProgress,
+        [taggedModelName]: {
+          ...prevProgress[taggedModelName],
+          error: errorToString(e),
+        },
+      }));
     }
   };
 
   useEffect(() => {
     let active = true;
-    const updateStream = (progress: ProgressResponse) => {
+
+    const updateStream = (modelName: string, progress: ProgressResponse) => {
       if (!active) return;
-      setDownloadProgress(progress);
+      setDownloadProgress((prevProgress) => ({
+        ...prevProgress,
+        [modelName]: {
+          ...prevProgress[modelName],
+          progress,
+        },
+      }));
     };
 
     window.ipcRenderer.receive("ollamaDownloadProgress", updateStream);
@@ -55,11 +74,14 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="w-[400px] ml-2 mr-2 mb-2 pl-3">
-        <h2 className="text-white  font-semibold mb-0">New Local Model</h2>
+        <h2 className="text-white  font-semibold mb-0">New Local LLM</h2>
         <p className="text-white text-sm mb-2 mt-1">
-          To use paste the name of the model you want to use below. It will be
-          downloaded automatically. You can find models on the{" "}
-          <ExternalLink url="https://ollama.com/library" label="Ollama Hub" />.
+          Reor will automaticaly download an LLM. Please choose an LLM from the{" "}
+          <ExternalLink
+            url="https://ollama.com/library"
+            label="Ollama Library"
+          />{" "}
+          and paste the name of the LLM below:
         </p>
 
         <input
@@ -71,8 +93,9 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
         />
         <p className="text-white text-xs mb-2 mt-2 italic">
           {" "}
-          We recommended either mistral, llama2, or phi.
+          We recommended either mistral, llama2, or gemma.
         </p>
+
         <Button
           className="bg-slate-700 border-none h-8 hover:bg-slate-900 cursor-pointer w-[100px] text-center pt-0 pb-0 pr-2 pl-2 mt-3"
           onClick={downloadSelectedModel}
@@ -80,22 +103,39 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
         >
           Download
         </Button>
-        {downloadProgress && !error && (
-          <p className="text-white text-sm mt-2">
-            {downloadProgress.status === "success" ? (
-              "Download complete! Refresh the chat window to use the new model."
-            ) : (
-              <>
-                Download progress: {downloadPercentage(downloadProgress)}
-                <p className="text-xs">
-                  (You can close this. The download will continue in the
-                  background)
-                </p>
-              </>
-            )}
-          </p>
+        {modelNameerror && (
+          <p className="text-xs text-red-500 break-words">{modelNameerror}</p>
         )}
-        {error && <p className="text-xs text-red-500 break-words">{error}</p>}
+        <div>
+          {Object.entries(downloadProgress).map(
+            ([modelName, { progress, error }]) => (
+              <div key={modelName} className="mb-4">
+                {!error && progress.status === "success" ? (
+                  <p className="text-white text-sm">
+                    {`${modelName}: Download complete! Refresh the chat window to use the new model.`}
+                  </p>
+                ) : !error ? (
+                  <>
+                    <p className="text-white text-sm">
+                      {`${modelName}: Download progress - ${downloadPercentage(
+                        progress
+                      )}`}
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-red-500 text-sm break-words">
+                    {`${modelName}: Error - ${error}`}
+                  </p>
+                )}
+              </div>
+            )
+          )}
+          {Object.entries(downloadProgress).length > 0 && (
+            <p className="text-white text-xs">
+              (Feel free to close this modal while the download completes.)
+            </p>
+          )}
+        </div>
       </div>
     </Modal>
   );
@@ -116,7 +156,6 @@ const downloadPercentage = (progress: ProgressResponse): string => {
     return "checking...";
   }
 
-  console.log("return percentage");
   const percentage = (100 * progress.completed) / progress.total;
 
   return percentage.toFixed(2) + "%";

--- a/src/components/Settings/ExtraModals/NewOllamaModel.tsx
+++ b/src/components/Settings/ExtraModals/NewOllamaModel.tsx
@@ -83,7 +83,7 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
         {downloadProgress && !error && (
           <p className="text-white text-sm mt-2">
             {downloadProgress.status === "success" ? (
-              "Download complete! Refrsh the chat window to use the new model."
+              "Download complete! Refresh the chat window to use the new model."
             ) : (
               <>
                 Download Progress:{" "}

--- a/src/components/Settings/ExtraModals/NewOllamaModel.tsx
+++ b/src/components/Settings/ExtraModals/NewOllamaModel.tsx
@@ -88,7 +88,10 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
               <>
                 Download Progress:{" "}
                 {downloadPercentage(downloadProgress).toFixed(2)}%.
-                <p className="text-xs">(You can close this Window)</p>
+                <p className="text-xs">
+                  (You can close this. The download will continue in the
+                  background)
+                </p>
               </>
             )}
           </p>

--- a/src/components/Settings/ExtraModals/NewOllamaModel.tsx
+++ b/src/components/Settings/ExtraModals/NewOllamaModel.tsx
@@ -86,8 +86,7 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
               "Download complete! Refresh the chat window to use the new model."
             ) : (
               <>
-                Download Progress:{" "}
-                {downloadPercentage(downloadProgress).toFixed(2)}%.
+                Download progress: {downloadPercentage(downloadProgress)}
                 <p className="text-xs">
                   (You can close this. The download will continue in the
                   background)
@@ -104,23 +103,21 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
 
 export default NewOllamaModelModal;
 
-const downloadPercentage = (progress: ProgressResponse): number => {
-  if (progress.status === "success") {
-    return 100;
-  }
-
+const downloadPercentage = (progress: ProgressResponse): string => {
   // Check if `total` is 0, undefined, or not a number to avoid division by zero or invalid operations
-  if (!progress.total || isNaN(progress.total) || progress.total === 0) {
+  if (
+    !progress.total ||
+    isNaN(progress.total) ||
+    progress.total === 0 ||
+    !progress.completed ||
+    isNaN(progress.completed)
+  ) {
     // Depending on your logic, you might want to return 0, or handle this case differently
-    return 0;
+    return "checking...";
   }
 
-  // Similarly, ensure `completed` is a valid number
-  const completed = isNaN(progress.completed) ? 0 : progress.completed;
+  console.log("return percentage");
+  const percentage = (100 * progress.completed) / progress.total;
 
-  // Calculate the download percentage
-  const percentage = (100 * completed) / progress.total;
-
-  // Optional: clamp the value between 0 and 100 if needed
-  return Math.max(0, Math.min(percentage, 100));
+  return percentage.toFixed(2) + "%";
 };


### PR DESCRIPTION
- Manage ollama server in steps (same implementation as chatd):
    1. Ping to check if ollama is running
    2. Attempt to start if "ollama" alias present
    3. Start ollama via the binary
- Add ollama stop call and call stop on before-quit

Other improvements:
- Createwindow function now in windowManager
- registerHandler functions run in main like other handlers - to ensure they don't run twice and error (when a window is closed and then reopened)


Remaining todos for another PR:
- Manage multiple downloads at once via sending modelname via ipc event send
- Also solve the flickering at the end of a download between 0 and 100%
- Update wording on new local model page