### PR TITLE
allow frontend to properly remove event listener on useffect unmount

### DIFF
--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -23,7 +23,6 @@ declare global {
   interface Window {
     ipcRenderer: {
       on: (channel: string, listener: (...args: unknown[]) => void) => void;
-      // removeListener: (channel: string, listener: ReceiveCallback) => void;
       receive: (channel: string, callback: ReceiveCallback) => () => void;
     };
     electron: {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { IpcRendererEvent, contextBridge, ipcRenderer } from "electron";
 import {
   EmbeddingModelConfig,
   EmbeddingModelWithLocalPath,
@@ -23,8 +23,8 @@ declare global {
   interface Window {
     ipcRenderer: {
       on: (channel: string, listener: (...args: unknown[]) => void) => void;
-      removeListener: (channel: string, listener: ReceiveCallback) => void;
-      receive: (channel: string, callback: ReceiveCallback) => void;
+      // removeListener: (channel: string, listener: ReceiveCallback) => void;
+      receive: (channel: string, callback: ReceiveCallback) => () => void;
     };
     electron: {
       openExternal: (url: string) => void;
@@ -203,9 +203,15 @@ contextBridge.exposeInMainWorld("electronStore", {
 
 contextBridge.exposeInMainWorld("ipcRenderer", {
   on: ipcRenderer.on,
-  removeListener: ipcRenderer.removeListener,
   receive: (channel: string, callback: (...args: unknown[]) => void) => {
-    ipcRenderer.on(channel, (event, ...args) => callback(...args));
+    // this creates a constant copy of the callback, thus ensuring that the removed listener is the same as the one added
+    const subscription = (event: IpcRendererEvent, ...args: unknown[]) =>
+      callback(...args);
+
+    ipcRenderer.on(channel, subscription);
+    return () => {
+      ipcRenderer.removeListener(channel, subscription);
+    };
   },
 });
 

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -144,9 +144,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({ currentFilePath }) => {
   };
 
   useEffect(() => {
-    let active = true;
     const updateStream = (chunk: ChatCompletionChunk) => {
-      if (!active) return;
       const newMsgContent = chunk.choices[0].delta.content;
       if (!newMsgContent) return;
       setCurrentBotMessage((prev) => {
@@ -158,11 +156,13 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({ currentFilePath }) => {
       });
     };
 
-    window.ipcRenderer.receive("tokenStream", updateStream);
+    const removeTokenStreamListener = window.ipcRenderer.receive(
+      "tokenStream",
+      updateStream
+    );
 
     return () => {
-      active = false;
-      window.ipcRenderer.removeListener("tokenStream", updateStream);
+      removeTokenStreamListener();
     };
   }, []);
 

--- a/src/components/File/FileSideBar/hooks/use-file-info-tree.tsx
+++ b/src/components/File/FileSideBar/hooks/use-file-info-tree.tsx
@@ -47,10 +47,13 @@ export const useFileInfoTree = (currentFilePath: string | null) => {
       setExpandedDirectories(directoriesToBeExpanded);
     };
 
-    window.ipcRenderer.receive("files-list", handleFileUpdate);
+    const removeFilesListListener = window.ipcRenderer.receive(
+      "files-list",
+      handleFileUpdate
+    );
 
     return () => {
-      window.ipcRenderer.removeListener("files-list", handleFileUpdate);
+      removeFilesListListener();
     };
   }, [currentFilePath]);
 

--- a/src/components/File/hooks/use-file-by-filepath.ts
+++ b/src/components/File/hooks/use-file-by-filepath.ts
@@ -93,13 +93,7 @@ export const useFileByFilepath = () => {
 
   // delete file depending on file path returned by the listener
   useEffect(() => {
-    let active = true;
-    console.log("now active");
     const deleteFile = async (path: string) => {
-      console.log("listener got file path: ", path);
-      if (!active) return;
-      console.log("listener is active");
-
       await window.files.deleteFile(path);
 
       // if it is the current file, clear the content and set filepath to null so that it won't save anything else
@@ -109,12 +103,13 @@ export const useFileByFilepath = () => {
       }
     };
 
-    window.ipcRenderer.receive("delete-file-listener", deleteFile);
+    const removeDeleteFileListener = window.ipcRenderer.receive(
+      "delete-file-listener",
+      deleteFile
+    );
 
     return () => {
-      active = false;
-      console.log("cleanup effect ran");
-      window.ipcRenderer.removeListener("delete-file-listener", deleteFile);
+      removeDeleteFileListener();
     };
   }, [currentlyOpenedFilePath, editor]);
 
@@ -154,14 +149,14 @@ export const useFileByFilepath = () => {
       window.electron.destroyWindow();
     };
 
-    window.ipcRenderer.receive("prepare-for-window-close", handleWindowClose);
+    const removeWindowCloseListener = window.ipcRenderer.receive(
+      "prepare-for-window-close",
+      handleWindowClose
+    );
 
     return () => {
       active = false;
-      window.ipcRenderer.removeListener(
-        "prepare-for-window-close",
-        handleWindowClose
-      );
+      removeWindowCloseListener();
     };
   }, [currentlyOpenedFilePath, editor]);
 

--- a/src/components/Settings/ExtraModals/NewOllamaModel.tsx
+++ b/src/components/Settings/ExtraModals/NewOllamaModel.tsx
@@ -50,10 +50,7 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
   };
 
   useEffect(() => {
-    let active = true;
-
     const updateStream = (modelName: string, progress: ProgressResponse) => {
-      if (!active) return;
       setDownloadProgress((prevProgress) => ({
         ...prevProgress,
         [modelName]: {
@@ -63,11 +60,13 @@ const NewOllamaModelModal: React.FC<NewOllamaModelModalProps> = ({
       }));
     };
 
-    window.ipcRenderer.receive("ollamaDownloadProgress", updateStream);
+    const removeOllamaDownloadProgressListener = window.ipcRenderer.receive(
+      "ollamaDownloadProgress",
+      updateStream
+    );
 
     return () => {
-      active = false;
-      window.ipcRenderer.removeListener("ollamaDownloadProgress", updateStream);
+      removeOllamaDownloadProgressListener();
     };
   }, []);
 

--- a/src/components/Similarity/SimilarFilesSidebar.tsx
+++ b/src/components/Similarity/SimilarFilesSidebar.tsx
@@ -71,23 +71,17 @@ const SimilarEntriesComponent: React.FC<SimilarEntriesComponentProps> = ({
   }, [filePath]);
 
   useEffect(() => {
-    let active = true;
     const vectorDBUpdateListener = async () => {
-      if (!active) return;
       console.log("Vector DB update listener path: ", filePath);
       updateSimilarEntries(filePath);
     };
 
-    window.ipcRenderer.receive(
+    const removeVectorDBListener = window.ipcRenderer.receive(
       "vector-database-update",
       vectorDBUpdateListener
     );
     return () => {
-      active = false;
-      window.ipcRenderer.removeListener(
-        "vector-database-update",
-        vectorDBUpdateListener
-      );
+      removeVectorDBListener();
     };
   }, [filePath]);
 


### PR DESCRIPTION
The IPC communication process causes functions sent across to be deserialized and serialized, hence the listeners are mutating reference and cannot be removed from the frontend since the function instances are different. 

By making the receive command return the remove event listener function, we are able to properly maintain the reference to the function that was being added to the channel and thus remove it cleanly. Now we dont need the `active` or not hack in useEffect.