### PR TITLE
add flashcard custom prompt

### DIFF
--- a/electron/main/Files/registerFilesHandler.ts
+++ b/electron/main/Files/registerFilesHandler.ts
@@ -211,9 +211,11 @@ export const registerFileHandlers = (
         if (!llmConfig) {
           throw new Error(`LLM ${llmName} not configured.`);
         }
+        const systemPrompt = "Based on the following information:\n";
         const { prompt: filePrompt, contextCutoffAt } =
           createPromptWithContextLimitFromContent(
             content,
+            systemPrompt,
             prompt,
             llmSession.getTokenizer(llmName),
             llmConfig.contextLength

--- a/electron/main/Prompts/Prompts.ts
+++ b/electron/main/Prompts/Prompts.ts
@@ -6,13 +6,12 @@ export interface PromptWithContextLimit {
 
 export function createPromptWithContextLimitFromContent(
   content: string | DBEntry[],
+  basePrompt: string,
   query: string,
   tokenize: (text: string) => number[],
   contextLimit: number
 ): PromptWithContextLimit {
-  const basePrompt =
-    "Answer the question below based on the following notes:\n ";
-  const queryPrompt = `Question: ${query}`;
+  const queryPrompt = `Given the above: ${query}`;
   let tokenCount = tokenize(queryPrompt + basePrompt).length;
 
   const contentArray: string[] = [];
@@ -24,7 +23,7 @@ export function createPromptWithContextLimitFromContent(
 
   for (const line of contents) {
     const lineWithNewLine = line + "\n";
-    if (tokenize(lineWithNewLine).length + tokenCount < contextLimit) {
+    if (tokenize(lineWithNewLine).length + tokenCount < contextLimit * 0.9) {
       tokenCount += tokenize(lineWithNewLine).length;
       contentArray.push(lineWithNewLine);
     } else if (cutOffLine.length === 0) {

--- a/electron/main/Prompts/Prompts.ts
+++ b/electron/main/Prompts/Prompts.ts
@@ -11,8 +11,7 @@ export function createPromptWithContextLimitFromContent(
   tokenize: (text: string) => number[],
   contextLimit: number
 ): PromptWithContextLimit {
-  const queryPrompt = `Given the above: ${query}`;
-  let tokenCount = tokenize(queryPrompt + basePrompt).length;
+  let tokenCount = tokenize(query + basePrompt).length;
 
   const contentArray: string[] = [];
   let cutOffLine: string = "";
@@ -31,7 +30,7 @@ export function createPromptWithContextLimitFromContent(
     }
   }
 
-  const outputPrompt = basePrompt + contentArray.join("") + queryPrompt;
+  const outputPrompt = basePrompt + contentArray.join("") + query;
 
   return {
     prompt: outputPrompt,

--- a/electron/main/database/dbSessionHandlerTypes.ts
+++ b/electron/main/database/dbSessionHandlerTypes.ts
@@ -1,5 +1,5 @@
 export interface BasePromptRequirements {
   query: string;
   llmName: string;
-  currentFilePath?: string;
+  filePathToBeUsedAsContext?: string;
 }

--- a/electron/main/database/dbSessionHandlerTypes.ts
+++ b/electron/main/database/dbSessionHandlerTypes.ts
@@ -1,0 +1,4 @@
+export interface BasePromptRequirements {
+  query: string;
+  llmName: string;
+}

--- a/electron/main/database/dbSessionHandlerTypes.ts
+++ b/electron/main/database/dbSessionHandlerTypes.ts
@@ -1,4 +1,5 @@
 export interface BasePromptRequirements {
   query: string;
   llmName: string;
+  currentFilePath?: string;
 }

--- a/electron/main/database/dbSessionHandlers.ts
+++ b/electron/main/database/dbSessionHandlers.ts
@@ -1,4 +1,6 @@
 import { ipcMain } from "electron";
+import * as fs from "fs";
+
 import { createPromptWithContextLimitFromContent } from "../Prompts/Prompts";
 import { DBEntry, DBQueryResult, DatabaseFields } from "./Schema";
 import { ollamaService, openAISession } from "../llm/llmSessionHandlers";
@@ -83,8 +85,11 @@ export const registerDBSessionHandlers = (
         const filteredResults = searchResults.filter(
           (entry) => entry._distance < MAX_COSINE_DISTANCE
         );
+        const basePrompt =
+          "Answer the question below based on the following notes:\n";
         const { prompt: ragPrompt } = createPromptWithContextLimitFromContent(
           filteredResults,
+          basePrompt,
           query,
           llmSession.getTokenizer(llmName),
           llmConfig.contextLength
@@ -177,9 +182,11 @@ For your reference, the timestamp right now is ${formatTimestampForLanceDB(
           );
           searchResults = [];
         }
-
+        const basePrompt =
+          "Answer the question below based on the following notes:\n";
         const { prompt: ragPrompt } = createPromptWithContextLimitFromContent(
           searchResults,
+          basePrompt,
           query,
           llmSession.getTokenizer(llmName),
           llmConfig.contextLength
@@ -204,7 +211,7 @@ For your reference, the timestamp right now is ${formatTimestampForLanceDB(
     "augment-prompt-with-flashcard-agent",
     async (
       event,
-      { query, llmName }: BasePromptRequirements
+      { query, llmName, currentFilePath }: BasePromptRequirements
     ): Promise<PromptWithRagResults> => {
       const llmSession = openAISession;
       console.log("llmName:   ", llmName);
@@ -213,49 +220,46 @@ For your reference, the timestamp right now is ${formatTimestampForLanceDB(
       if (!llmConfig) {
         throw new Error(`LLM ${llmName} not configured.`);
       }
-
-      let searchResults: DBEntry[] = [];
-      const maxRAGExamples: number = store.get(StoreKeys.MaxRAGExamples);
-      const windowInfo = windowManager.getWindowInfoForContents(event.sender);
-      if (!windowInfo) {
-        throw new Error("Window info not found.");
-      }
-
-      try {
-        searchResults = await windowInfo.dbTableClient.search(
-          query,
-          maxRAGExamples
+      if (!currentFilePath) {
+        throw new Error(
+          "Current file path is not provided for flashcard agent."
         );
-      } catch (error) {
-        searchResults = await windowInfo.dbTableClient.search(
-          query,
-          maxRAGExamples
-        );
-        console.error("Error searching database:", error);
-        throw errorToString(error);
       }
-
+      const fileResults = fs.readFileSync(currentFilePath, "utf-8");
+      const { prompt: promptToCreateAtomicFacts } =
+        createPromptWithContextLimitFromContent(
+          fileResults,
+          "",
+          `Extract atomic facts that can be used for students to study, based on this query: ${query}`,
+          llmSession.getTokenizer(llmName),
+          llmConfig.contextLength
+        );
       const llmGeneratedFacts = await llmSession.response(
         llmName,
         llmConfig,
         [
           {
             role: "system",
-            content: `You are an experienced teacher. Help your student search and curate their notes!`,
+            content: `You are an experienced teacher reading through some notes a student has made and extracting atomic facts. You never come up with your own facts. You generate atomic facts directly from what you read.
+            An atomic fact is a fact that relates to a single piece of knowledge and makes it easy to create a question for which the atomic fact is the answer"`,
           },
           {
             role: "user",
-            content: `Extract atomic facts that can be used for students to study, based on this query: ${query}`,
+            content: promptToCreateAtomicFacts,
           },
         ],
         store.get(StoreKeys.LLMGenerationParameters)
       );
 
       console.log(llmGeneratedFacts);
+      const basePrompt = "Given the following atomic facts:\n";
+      const flashcardQuery =
+        "Create useful FLASHCARDS that can be used for students to study using ONLY the context. Format is Q: <insert question> A: <insert answer>";
       const { prompt: promptToCreateFlashcardsWithAtomicFacts } =
         createPromptWithContextLimitFromContent(
           llmGeneratedFacts.choices[0].message.content || "",
-          `Create useful FLASHCARDS that can be used for students to study using ONLY the context. Format is Q: <insert question> A: <insert answer>`,
+          basePrompt,
+          flashcardQuery,
           llmSession.getTokenizer(llmName),
           llmConfig.contextLength
         );
@@ -263,9 +267,7 @@ For your reference, the timestamp right now is ${formatTimestampForLanceDB(
         "promptToCreateFlashcardsWithAtomicFacts: ",
         promptToCreateFlashcardsWithAtomicFacts
       );
-      const uniqueFilesReferenced = [
-        ...new Set(searchResults.map((entry) => entry.notepath)),
-      ];
+      const uniqueFilesReferenced = [currentFilePath];
 
       return {
         ragPrompt: promptToCreateFlashcardsWithAtomicFacts,

--- a/electron/main/database/dbSessionHandlers.ts
+++ b/electron/main/database/dbSessionHandlers.ts
@@ -211,7 +211,7 @@ For your reference, the timestamp right now is ${formatTimestampForLanceDB(
     "augment-prompt-with-flashcard-agent",
     async (
       event,
-      { query, llmName, currentFilePath }: BasePromptRequirements
+      { query, llmName, filePathToBeUsedAsContext }: BasePromptRequirements
     ): Promise<PromptWithRagResults> => {
       const llmSession = openAISession;
       console.log("llmName:   ", llmName);
@@ -220,12 +220,12 @@ For your reference, the timestamp right now is ${formatTimestampForLanceDB(
       if (!llmConfig) {
         throw new Error(`LLM ${llmName} not configured.`);
       }
-      if (!currentFilePath) {
+      if (!filePathToBeUsedAsContext) {
         throw new Error(
           "Current file path is not provided for flashcard agent."
         );
       }
-      const fileResults = fs.readFileSync(currentFilePath, "utf-8");
+      const fileResults = fs.readFileSync(filePathToBeUsedAsContext, "utf-8");
       const { prompt: promptToCreateAtomicFacts } =
         createPromptWithContextLimitFromContent(
           fileResults,
@@ -267,7 +267,7 @@ For your reference, the timestamp right now is ${formatTimestampForLanceDB(
         "promptToCreateFlashcardsWithAtomicFacts: ",
         promptToCreateFlashcardsWithAtomicFacts
       );
-      const uniqueFilesReferenced = [currentFilePath];
+      const uniqueFilesReferenced = [filePathToBeUsedAsContext];
 
       return {
         ragPrompt: promptToCreateFlashcardsWithAtomicFacts,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -18,6 +18,7 @@ import { DBEntry, DBQueryResult } from "electron/main/database/Schema";
 import { PromptWithContextLimit } from "electron/main/Prompts/Prompts";
 import { PromptWithRagResults } from "electron/main/database/dbSessionHandlers";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import { BasePromptRequirements } from "electron/main/database/dbSessionHandlerTypes";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ReceiveCallback = (...args: any[]) => void;
 
@@ -53,6 +54,10 @@ declare global {
         prompt: string,
         llmName: string
       ) => Promise<PromptWithRagResults>;
+      augmentPromptWithFlashcardAgent: ({
+        query,
+        llmName,
+      }: BasePromptRequirements) => Promise<PromptWithRagResults>;
       getDatabaseFields: () => Promise<Record<string, string>>;
     };
     files: {
@@ -152,6 +157,16 @@ contextBridge.exposeInMainWorld("database", {
       prompt,
       llmName
     );
+  },
+  augmentPromptWithFlashcardAgent: async ({
+    query,
+    llmName,
+  }: BasePromptRequirements): Promise<PromptWithRagResults> => {
+    console.log(llmName, query);
+    return ipcRenderer.invoke("augment-prompt-with-flashcard-agent", {
+      query,
+      llmName,
+    });
   },
   getDatabaseFields: async (): Promise<Record<string, string>> => {
     return ipcRenderer.invoke("get-database-fields");

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -57,6 +57,7 @@ declare global {
       augmentPromptWithFlashcardAgent: ({
         query,
         llmName,
+        currentFilePath,
       }: BasePromptRequirements) => Promise<PromptWithRagResults>;
       getDatabaseFields: () => Promise<Record<string, string>>;
     };
@@ -161,11 +162,13 @@ contextBridge.exposeInMainWorld("database", {
   augmentPromptWithFlashcardAgent: async ({
     query,
     llmName,
+    currentFilePath,
   }: BasePromptRequirements): Promise<PromptWithRagResults> => {
     console.log(llmName, query);
     return ipcRenderer.invoke("augment-prompt-with-flashcard-agent", {
       query,
       llmName,
+      currentFilePath,
     });
   },
   getDatabaseFields: async (): Promise<Record<string, string>> => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -57,7 +57,7 @@ declare global {
       augmentPromptWithFlashcardAgent: ({
         query,
         llmName,
-        currentFilePath,
+        filePathToBeUsedAsContext,
       }: BasePromptRequirements) => Promise<PromptWithRagResults>;
       getDatabaseFields: () => Promise<Record<string, string>>;
     };
@@ -162,13 +162,13 @@ contextBridge.exposeInMainWorld("database", {
   augmentPromptWithFlashcardAgent: async ({
     query,
     llmName,
-    currentFilePath,
+    filePathToBeUsedAsContext,
   }: BasePromptRequirements): Promise<PromptWithRagResults> => {
     console.log(llmName, query);
     return ipcRenderer.invoke("augment-prompt-with-flashcard-agent", {
       query,
       llmName,
-      currentFilePath,
+      filePathToBeUsedAsContext,
     });
   },
   getDatabaseFields: async (): Promise<Record<string, string>> => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -50,10 +50,10 @@ declare global {
         llmName: string,
         filter?: string
       ) => Promise<PromptWithRagResults>;
-      augmentPromptWithTemporalAgent: (
-        prompt: string,
-        llmName: string
-      ) => Promise<PromptWithRagResults>;
+      augmentPromptWithTemporalAgent: ({
+        query,
+        llmName,
+      }: BasePromptRequirements) => Promise<PromptWithRagResults>;
       augmentPromptWithFlashcardAgent: ({
         query,
         llmName,
@@ -149,15 +149,14 @@ contextBridge.exposeInMainWorld("database", {
       filter
     );
   },
-  augmentPromptWithTemporalAgent: async (
-    prompt: string,
-    llmName: string
-  ): Promise<PromptWithRagResults> => {
-    return ipcRenderer.invoke(
-      "augment-prompt-with-temporal-agent",
-      prompt,
-      llmName
-    );
+  augmentPromptWithTemporalAgent: async ({
+    query,
+    llmName,
+  }: BasePromptRequirements): Promise<PromptWithRagResults> => {
+    return ipcRenderer.invoke("augment-prompt-with-temporal-agent", {
+      query,
+      llmName,
+    });
   },
   augmentPromptWithFlashcardAgent: async ({
     query,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reor-project",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reor-project",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -75,14 +75,17 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
 
   const fileNotSelectedToastId = useRef<string | null>(null);
   useEffect(() => {
-    if (!currentFilePath && askText === AskOptions.AskFile) {
+    if (
+      !currentFilePath &&
+      (askText === AskOptions.AskFile || askText === AskOptions.FlashcardAsk)
+    ) {
       fileNotSelectedToastId.current = toast.error(
         `Please open a file before asking questions in ${askText} mode`,
         {}
       ) as string;
     } else if (
       currentFilePath &&
-      askText === AskOptions.AskFile &&
+      (askText === AskOptions.AskFile || askText === AskOptions.FlashcardAsk) &&
       fileNotSelectedToastId.current
     ) {
       toast.dismiss(fileNotSelectedToastId.current);
@@ -91,6 +94,8 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
 
   const handleSubmitNewMessage = async () => {
     if (loadingResponse) return;
+    if (!userTextFieldInput.trim()) return;
+
     let newMessages = messages;
     if (currentBotMessage) {
       newMessages = [
@@ -109,7 +114,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
         role: "assistant",
       });
     }
-    if (!userTextFieldInput.trim()) return;
+
     const llmName = await window.llm.getDefaultLLMName();
 
     let augmentedPrompt: string = "";
@@ -165,10 +170,10 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
         augmentedPrompt = ragPrompt;
       } else if (askText === AskOptions.TemporalAsk) {
         const { ragPrompt, uniqueFilesReferenced } =
-          await window.database.augmentPromptWithTemporalAgent(
-            userTextFieldInput,
-            llmName
-          );
+          await window.database.augmentPromptWithTemporalAgent({
+            query: userTextFieldInput,
+            llmName,
+          });
         augmentedPrompt = ragPrompt;
         setFilesReferenced(uniqueFilesReferenced);
       } else if (askText === AskOptions.FlashcardAsk && currentFilePath) {

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -35,6 +35,7 @@ const EXAMPLE_PROMPTS: { [key: string]: string[] } = {
     "Summarize what I have worked on today",
     "Which tasks have I completed this past week?",
   ],
+  [AskOptions.FlashcardAsk]: [],
 };
 
 type ChatUIMessage = {
@@ -55,7 +56,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
   const [userTextFieldInput, setUserTextFieldInput] = useState<string>("");
   const [messages, setMessages] = useState<ChatUIMessage[]>([]);
   const [defaultModel, setDefaultModel] = useState<string>("");
-  const [askText, setAskText] = useState<string>("Ask");
+  const [askText, setAskText] = useState<AskOptions>(AskOptions.Ask);
   const [loadingResponse, setLoadingResponse] = useState<boolean>(false);
   const [filesReferenced, setFilesReferenced] = useState<string[]>([]);
   const [currentBotMessage, setCurrentBotMessage] =

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -21,6 +21,7 @@ enum AskOptions {
   Ask = "Ask",
   AskFile = "Ask File",
   TemporalAsk = "Temporal Ask",
+  FlashcardAsk = "Flashcard Ask",
 }
 const ASK_OPTIONS = Object.values(AskOptions);
 
@@ -153,6 +154,19 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           );
         augmentedPrompt = ragPrompt;
         setFilesReferenced(uniqueFilesReferenced);
+      } else if (askText === AskOptions.FlashcardAsk) {
+        console.log(llmName);
+        const { ragPrompt, uniqueFilesReferenced } =
+          await window.database.augmentPromptWithFlashcardAgent({
+            query: userTextFieldInput,
+            llmName,
+          });
+
+        console.log("RAG Prompt:", ragPrompt);
+        console.log("Unique files referenced:", uniqueFilesReferenced);
+
+        setFilesReferenced(uniqueFilesReferenced);
+        augmentedPrompt = ragPrompt;
       }
     } catch (error) {
       console.error("Failed to augment prompt:", error);

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -176,7 +176,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           await window.database.augmentPromptWithFlashcardAgent({
             query: userTextFieldInput,
             llmName,
-            currentFilePath,
+            filePathToBeUsedAsContext: currentFilePath,
           });
 
         console.log("RAG Prompt:", ragPrompt);


### PR DESCRIPTION
Generally got it working to output the right format pretty reliably, but the RAG pipeline still isnt picking up on:
1. The name of the note(we really need to add this, the results here use the entirely wrong note for it), and hybrid text search
2. It isn't aware of alternative concepts related to the same question I am making

it is outside of the scope of this PR, but I would probably work on hybrid text search next

![image](https://github.com/reorproject/reor/assets/58682208/54f60f99-2af2-49dc-a587-e85ced272c15)


Future work for these custom prompts require:
1. Separate steps to generate the prompt
2. Emphasize/select previous output when generating next prompt (maybe some sort of a prior filter or selector component)
3. Allow it to generate intermediate output, and conditionally take in previous context
4. Some warning for prompt exceeding token limits (now that we can have this idea of loading atomic facts into prompt, it might actually get overloaded)