### PR TITLE
introduce state to deal with whether current editor content has been indexed

### DIFF
--- a/src/components/File/NewNote.tsx
+++ b/src/components/File/NewNote.tsx
@@ -1,20 +1,18 @@
 import React, { useState } from "react";
 import Modal from "../Generic/Modal";
 import { Button } from "@material-tailwind/react";
-import { toast } from "react-toastify";
-import { errorToString } from "@/functions/error";
 import { getInvalidCharacterInFilePath } from "@/functions/strings";
 
 interface NewNoteComponentProps {
   isOpen: boolean;
   onClose: () => void;
-  onFileSelect: (path: string) => void;
+  openRelativePath: (path: string) => void;
 }
 
 const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
   isOpen,
   onClose,
-  onFileSelect,
+  openRelativePath,
 }) => {
   const [fileName, setFileName] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -35,26 +33,11 @@ const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
   };
 
   const sendNewNoteMsg = async () => {
-    try {
-      if (!fileName || errorMessage) {
-        return;
-      }
-      const normalizedFileName = fileName.slice(0, 255).replace(/\\/g, "/");
-      const fullPath = await window.path.join(
-        await window.electronStore.getVaultDirectoryForWindow(),
-        await window.path.addExtensionIfNoExtensionPresent(normalizedFileName)
-      );
-      window.files.createFile(fullPath, `# ${fileName}\n`);
-      onFileSelect(fullPath);
-      onClose();
-    } catch (e) {
-      toast.error(errorToString(e), {
-        className: "mt-5",
-        autoClose: false,
-        closeOnClick: false,
-        draggable: false,
-      });
+    if (!fileName || errorMessage) {
+      return;
     }
+    openRelativePath(fileName);
+    onClose();
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -82,7 +82,6 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
       <div className="flex h-below-titlebar">
         <div className="w-[35px] border-l-0 border-b-0 border-t-0 border-r-[0.001px] border-neutral-700 border-solid">
           <LeftSidebar
-            onFileSelect={openFileByPath}
             openRelativePath={openRelativePath}
             sidebarShowing={sidebarShowing}
             makeSidebarShow={setSidebarShowing}

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -24,6 +24,7 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
     filePath,
     editor,
     openFileByPath,
+    openRelativePath,
     saveCurrentlyOpenedFile,
     suggestionsState,
     highlightData,
@@ -82,6 +83,7 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
         <div className="w-[35px] border-l-0 border-b-0 border-t-0 border-r-[0.001px] border-neutral-700 border-solid">
           <LeftSidebar
             onFileSelect={openFileByPath}
+            openRelativePath={openRelativePath}
             sidebarShowing={sidebarShowing}
             makeSidebarShow={setSidebarShowing}
           />

--- a/src/components/Sidebars/IconsSidebar.tsx
+++ b/src/components/Sidebars/IconsSidebar.tsx
@@ -12,13 +12,13 @@ import { LuFolderPlus } from "react-icons/lu";
 import FlashcardReviewModal from "../Flashcard/FlashcardReviewModal";
 
 interface LeftSidebarProps {
-  onFileSelect: (path: string) => void;
+  openRelativePath: (path: string) => void;
   sidebarShowing: SidebarAbleToShow;
   makeSidebarShow: (show: SidebarAbleToShow) => void;
 }
 
 const LeftSidebar: React.FC<LeftSidebarProps> = ({
-  onFileSelect,
+  openRelativePath,
   sidebarShowing,
   makeSidebarShow,
 }) => {
@@ -106,7 +106,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
       <NewNoteComponent
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
-        onFileSelect={onFileSelect}
+        openRelativePath={openRelativePath}
       />
       <NewDirectoryComponent
         isOpen={isNewDirectoryModalOpen}


### PR DESCRIPTION
Given that we write to disk and index editor content at different intervals, that requires some state to know when we need to index the content to the database:

- PR introduces ```needToIndexEditorContent``` state variable
- Makes newnote component use ```openRelativePath``` function so that we don't need to duplicate logic in different files