### PR TITLE
second try at adding files filters

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -198,6 +198,16 @@ ipcMain.handle("show-context-menu-file-item", (event, file) => {
     })
   );
 
+  menu.append(
+    new MenuItem({
+      label: "Add file to chat context",
+      click: () => {
+        console.log("creating: ", file.path);
+        event.sender.send("add-file-to-chat-listener", file.path);
+      },
+    })
+  );
+
   console.log("menu key: ", file);
 
   const browserWindow = BrowserWindow.fromWebContents(event.sender);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reor-project",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reor-project",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@emotion/react": "^11.11.4",
@@ -14,6 +14,7 @@
         "@headlessui/react": "^1.7.19",
         "@huggingface/hub": "^0.12.0",
         "@material-tailwind/react": "^2.1.5",
+        "@mui/icons-material": "^5.15.15",
         "@mui/joy": "^5.0.0-beta.23",
         "@mui/material": "^5.15.11",
         "@radix-ui/colors": "^3.0.0",
@@ -3316,6 +3317,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.15.tgz",
+      "integrity": "sha512-kkeU/pe+hABcYDH6Uqy8RmIsr2S/y5bP2rp+Gat4CcRjCcVne6KudS1NrZQhUCRysrTDCAhcbcf9gt+/+pGO2g==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/joy": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@headlessui/react": "^1.7.19",
     "@huggingface/hub": "^0.12.0",
     "@material-tailwind/react": "^2.1.5",
+    "@mui/icons-material": "^5.15.15",
     "@mui/joy": "^5.0.0-beta.23",
     "@mui/material": "^5.15.11",
     "@radix-ui/colors": "^3.0.0",

--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -47,7 +47,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      <div className="ml-6 mt-2 mb-6 h-full">
+      <div className="ml-6 mt-2 mb-6 h-full w-[600px]">
         <SearchBarWithFilesSuggestion
           vaultDirectory={vaultDirectory}
           titleText={titleText}

--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -15,7 +15,6 @@ interface Props {
   vaultDirectory: string;
   setChatFilters: (chatFilters: ChatFilters) => void;
   chatFilters: ChatFilters;
-  maxSuggestionWidth?: string;
 }
 
 const AddContextFiltersModal: React.FC<Props> = ({
@@ -25,7 +24,6 @@ const AddContextFiltersModal: React.FC<Props> = ({
   titleText,
   chatFilters,
   setChatFilters,
-  maxSuggestionWidth,
 }) => {
   const [internalFilesSelected, setInternalFilesSelected] = useState<string[]>(
     chatFilters?.files || []
@@ -49,7 +47,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
-      <div className="ml-6 mt-2 mb-6 w-[900px] h-full">
+      <div className="ml-6 mt-2 mb-6 h-full">
         <SearchBarWithFilesSuggestion
           vaultDirectory={vaultDirectory}
           titleText={titleText}
@@ -67,9 +65,8 @@ const AddContextFiltersModal: React.FC<Props> = ({
           }}
           suggestionsState={suggestionsState}
           setSuggestionsState={setSuggestionsState}
-          maxSuggestionWidth={maxSuggestionWidth}
         />
-        <div className="text-white">
+        <div className="text-white max-w-lg">
           <List placeholder="">
             {internalFilesSelected.map((fileItem, index) => {
               return (
@@ -86,7 +83,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
         <div className="flex justify-end">
           {internalFilesSelected && (
             <Button
-              className="bg-slate-600 border-none h-20 w-48 text-center vertical-align
+              className="bg-slate-600 border-none h-8 w-48 text-center vertical-align
                 mt-4 mr-16
                 cursor-pointer
                 disabled:pointer-events-none
@@ -98,7 +95,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
               placeholder={""}
             >
               <div className="flex items-center justify-around h-full space-x-2">
-                Add file
+                Add to context
               </div>
             </Button>
           )}

--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -6,7 +6,7 @@ import { SearchBarWithFilesSuggestion } from "../Generic/SearchBarWithFilesSugge
 import { SuggestionsState } from "../Editor/FilesSuggestionsDisplay";
 import { ChatFilters } from "./Chat";
 import { ListItemIcon, ListItemText } from "@mui/material";
-import FolderIcon from '@mui/icons-material/Folder';
+import FolderIcon from "@mui/icons-material/Folder";
 
 interface Props {
   isOpen: boolean;
@@ -27,22 +27,24 @@ const AddContextFiltersModal: React.FC<Props> = ({
   setChatFilters,
   maxSuggestionWidth,
 }) => {
-  const [internalFilesSelected, setInternalFilesSelected] = useState<string []>(chatFilters?.files || []);
+  const [internalFilesSelected, setInternalFilesSelected] = useState<string[]>(
+    chatFilters?.files || []
+  );
   const [searchText, setSearchText] = useState<string>("");
-  const [suggestionsState, setSuggestionsState] = useState<SuggestionsState | null>(null);
-
+  const [suggestionsState, setSuggestionsState] =
+    useState<SuggestionsState | null>(null);
 
   const handleAddFilesToChatFilters = (files: string[]) => {
-      const currentChatFilters: ChatFilters = chatFilters ?
-      {
-        ...chatFilters,
-        files: [...chatFilters.files, ...files],
-      } :
-      {
-        numberOfChunksToFetch: 15,
-        files: [...files],
-      };
-      setChatFilters(currentChatFilters);
+    const currentChatFilters: ChatFilters = chatFilters
+      ? {
+          ...chatFilters,
+          files: [...chatFilters.files, ...files],
+        }
+      : {
+          numberOfChunksToFetch: 15,
+          files: [...files],
+        };
+    setChatFilters(currentChatFilters);
   };
 
   return (
@@ -56,29 +58,30 @@ const AddContextFiltersModal: React.FC<Props> = ({
           onSelectSuggestion={(file: string) => {
             if (!internalFilesSelected.includes(file)) {
               //TODO: add markdown extension properly
-              setInternalFilesSelected([...internalFilesSelected, file + ".md"]);
+              setInternalFilesSelected([
+                ...internalFilesSelected,
+                file + ".md",
+              ]);
             }
             setSuggestionsState(null);
           }}
           suggestionsState={suggestionsState}
           setSuggestionsState={setSuggestionsState}
           maxSuggestionWidth={maxSuggestionWidth}
-          />
+        />
         <div className="text-white">
-            <List placeholder=''>
-              {internalFilesSelected.map((fileItem, index) => {
-                return (
-                  <ListItem key={index} placeholder=''>
-                    <ListItemIcon>
-                      <FolderIcon color="primary" />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={fileItem}
-                    />
-                  </ListItem>
-                );
-              })}
-              </List>
+          <List placeholder="">
+            {internalFilesSelected.map((fileItem, index) => {
+              return (
+                <ListItem key={index} placeholder="">
+                  <ListItemIcon>
+                    <FolderIcon color="primary" />
+                  </ListItemIcon>
+                  <ListItemText primary={fileItem} />
+                </ListItem>
+              );
+            })}
+          </List>
         </div>
         <div className="flex justify-end">
           {internalFilesSelected && (
@@ -89,7 +92,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
                 disabled:pointer-events-none
                 disabled:opacity-25"
               onClick={() => {
-                handleAddFilesToChatFilters(internalFilesSelected)
+                handleAddFilesToChatFilters(internalFilesSelected);
                 onClose();
               }}
               placeholder={""}
@@ -99,9 +102,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
               </div>
             </Button>
           )}
-
         </div>
-
       </div>
     </Modal>
   );

--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -56,7 +56,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
           searchText={searchText}
           setSearchText={setSearchText}
           onSelectSuggestion={(file: string) => {
-            if (!internalFilesSelected.includes(file)) {
+            if (file && !internalFilesSelected.includes(file)) {
               //TODO: add markdown extension properly
               setInternalFilesSelected([
                 ...internalFilesSelected,

--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -84,7 +84,6 @@ const AddContextFiltersModal: React.FC<Props> = ({
           {internalFilesSelected && (
             <Button
               className="bg-slate-600 border-none h-8 w-48 text-center vertical-align
-                mt-4 mr-16
                 cursor-pointer
                 disabled:pointer-events-none
                 disabled:opacity-25"

--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from "react";
+
+import Modal from "../Generic/Modal";
+import { Avatar, Button, List, ListItem } from "@material-tailwind/react";
+import { SearchBarWithFilesSuggestion } from "../Generic/SearchBarWithFilesSuggestion";
+import { SuggestionsState } from "../Editor/FilesSuggestionsDisplay";
+import { ChatFilters } from "./Chat";
+import { ListItemAvatar, ListItemIcon, ListItemText } from "@mui/material";
+import FolderIcon from '@mui/icons-material/Folder';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  titleText: string;
+  vaultDirectory: string;
+  setChatFilters: (chatFilters: ChatFilters) => void;
+  chatFilters: ChatFilters;
+  maxSuggestionWidth?: string;
+}
+
+const AddContextFiltersModal: React.FC<Props> = ({
+  vaultDirectory,
+  isOpen,
+  onClose,
+  titleText,
+  chatFilters,
+  setChatFilters,
+  maxSuggestionWidth,
+}) => {
+  const [internalFilesSelected, setInternalFilesSelected] = useState<string []>(chatFilters?.files || []);
+  const [searchText, setSearchText] = useState<string>("");
+  const [suggestionsState, setSuggestionsState] = useState<SuggestionsState | null>(null);
+
+
+  const handleAddFilesToChatFilters = (files: string[]) => {
+      const currentChatFilters: ChatFilters = chatFilters ?
+      {
+        ...chatFilters,
+        files: [...chatFilters.files, ...files],
+      } :
+      {
+        numberOfChunksToFetch: 15,
+        files: [...files],
+      };
+      setChatFilters(currentChatFilters);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="ml-6 mt-2 mb-6 w-[900px] h-full">
+        <SearchBarWithFilesSuggestion
+          vaultDirectory={vaultDirectory}
+          titleText={titleText}
+          searchText={searchText}
+          setSearchText={setSearchText}
+          onSelectSuggestion={(file: string) => {
+            if (!internalFilesSelected.includes(file)) {
+              //TODO: add markdown extension properly
+              setInternalFilesSelected([...internalFilesSelected, file + ".md"]);
+            }
+            setSuggestionsState(null);
+          }}
+          suggestionsState={suggestionsState}
+          setSuggestionsState={setSuggestionsState}
+          maxSuggestionWidth={maxSuggestionWidth}
+          />
+        <div className="text-white">
+            <List placeholder=''>
+              {internalFilesSelected.map((fileItem, index) => {
+                return (
+                  <ListItem key={index} placeholder=''>
+                    <ListItemIcon>
+                      <FolderIcon color="primary" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={fileItem}
+                    />
+                  </ListItem>
+                );
+              })}
+              </List>
+        </div>
+        <div className="flex justify-end">
+          {internalFilesSelected && (
+            <Button
+              className="bg-slate-600 border-none h-20 w-48 text-center vertical-align
+                mt-4 mr-16
+                cursor-pointer
+                disabled:pointer-events-none
+                disabled:opacity-25"
+              onClick={() => {
+                handleAddFilesToChatFilters(internalFilesSelected)
+                onClose();
+              }}
+              placeholder={""}
+            >
+              <div className="flex items-center justify-around h-full space-x-2">
+                Add file
+              </div>
+            </Button>
+          )}
+
+        </div>
+
+      </div>
+    </Modal>
+  );
+};
+
+export default AddContextFiltersModal;

--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
 
 import Modal from "../Generic/Modal";
-import { Avatar, Button, List, ListItem } from "@material-tailwind/react";
+import { Button, List, ListItem } from "@material-tailwind/react";
 import { SearchBarWithFilesSuggestion } from "../Generic/SearchBarWithFilesSuggestion";
 import { SuggestionsState } from "../Editor/FilesSuggestionsDisplay";
 import { ChatFilters } from "./Chat";
-import { ListItemAvatar, ListItemIcon, ListItemText } from "@mui/material";
+import { ListItemIcon, ListItemText } from "@mui/material";
 import FolderIcon from '@mui/icons-material/Folder';
 
 interface Props {

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -390,7 +390,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
     <div className="flex items-center justify-center w-full h-full">
       <div className="flex flex-col w-full h-full mx-auto overflow-hidden bg-neutral-800 border-l-[0.001px] border-b-0 border-t-0 border-r-0 border-neutral-700 border-solid">
         <div className="flex flex-col overflow-auto p-3 pt-0 bg-transparent h-full">
-          <div className="space-y-2 ml-4 mr-4 flex-grow">
+          <div className="space-y-2 mt-2 ml-4 mr-4 flex-grow">
             {currentChatHistory?.displayableChatHistory
               .filter((msg) => msg.role !== "system")
               .map((message, index) => (

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -129,7 +129,7 @@ export type ChatTemplate = {
 
 export const resolveRAGContext = async (
   query: string,
-  chatFilters: ChatFilters
+  chatFilters: ChatFilters,
 ): Promise<ChatMessageToDisplay> => {
   // I mean like the only real places to get context from are like particular files or semantic search or full text search.
   // and like it could be like that if a file is here
@@ -197,6 +197,20 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
     const context = getChatHistoryContext(currentChatHistory);
     setCurrentContext(context);
   }, [currentChatHistory]);
+
+  // update chat context when files are added
+  useEffect(() => {
+
+    const setContextOnFileAdded = async () => {
+      if (chatFilters.files.length > 0) {
+        const results = await window.files.getFilesystemPathsAsDBItems(chatFilters.files);
+        setCurrentContext(results as DBQueryResult[]);
+      } else {
+        setCurrentContext([]);
+      }
+    }
+    setContextOnFileAdded();
+  }, [chatFilters.files]);
 
   useEffect(() => {
     if (readyToSave && currentChatHistory) {

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -129,7 +129,7 @@ export type ChatTemplate = {
 
 export const resolveRAGContext = async (
   query: string,
-  chatFilters: ChatFilters,
+  chatFilters: ChatFilters
 ): Promise<ChatMessageToDisplay> => {
   // I mean like the only real places to get context from are like particular files or semantic search or full text search.
   // and like it could be like that if a file is here
@@ -144,7 +144,7 @@ export const resolveRAGContext = async (
       chatFilters.numberOfChunksToFetch
     );
   }
-  console.log("results", results)
+  console.log("results", results);
   return {
     messageType: "success",
     role: "user",
@@ -188,7 +188,8 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
   const [loadingResponse, setLoadingResponse] = useState<boolean>(false);
   const [readyToSave, setReadyToSave] = useState<boolean>(false);
   const [currentContext, setCurrentContext] = useState<DBQueryResult[]>([]);
-  const [isAddContextFiltersModalOpen, setIsAddContextFiltersModalOpen] = useState<boolean>(false);
+  const [isAddContextFiltersModalOpen, setIsAddContextFiltersModalOpen] =
+    useState<boolean>(false);
 
   // chat filters related state: this is the only thing that the Chat component cares about
   // chat component doesn't care about previous states and suggestions, and it can reset it
@@ -202,13 +203,15 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
   useEffect(() => {
     const setContextOnFileAdded = async () => {
       if (chatFilters.files.length > 0) {
-        const results = await window.files.getFilesystemPathsAsDBItems(chatFilters.files);
+        const results = await window.files.getFilesystemPathsAsDBItems(
+          chatFilters.files
+        );
         setCurrentContext(results as DBQueryResult[]);
       } else if (!currentChatHistory?.id) {
         // if there is no prior history, set current context to empty
         setCurrentContext([]);
       }
-    }
+    };
     setContextOnFileAdded();
   }, [chatFilters.files]);
 
@@ -234,7 +237,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           displayableChatHistory: [],
         };
       }
-      console.log(chatFilters)
+      console.log(chatFilters);
       if (chatHistory.displayableChatHistory.length === 0) {
         if (chatFilters) {
           // chatHistory.displayableChatHistory.push({
@@ -257,7 +260,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           context: [],
         });
       }
-      console.log(chatHistory)
+      console.log(chatHistory);
 
       setUserTextFieldInput("");
 
@@ -408,31 +411,37 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
                 </ReactMarkdown>
               ))}
           </div>
-          {
-            (!currentChatHistory || currentChatHistory?.displayableChatHistory.length == 0) && (
-              <>
-                <div className="flex items-center justify-center text-gray-300 text-sm">
-                  Start a conversation with your notes by typing a message below.
-                </div>
-                <div className="flex items-center justify-center text-gray-300 text-sm">
-                  <button className='bg-slate-600 m-2 rounded-lg border-none h-6 w-40 text-center vertical-align text-white '
-                      onClick={() => {
-                        setIsAddContextFiltersModalOpen(true)
-                    }}>
-                  {chatFilters.files.length > 0 ? "Update filters" : "Add filters"}
-                  </button>
-                </div>
-              </>
-            )
-          }
-          {isAddContextFiltersModalOpen && <AddContextFiltersModal
+          {(!currentChatHistory ||
+            currentChatHistory?.displayableChatHistory.length == 0) && (
+            <>
+              <div className="flex items-center justify-center text-gray-300 text-sm">
+                Start a conversation with your notes by typing a message below.
+              </div>
+              <div className="flex items-center justify-center text-gray-300 text-sm">
+                <button
+                  className="bg-slate-600 m-2 rounded-lg border-none h-6 w-40 text-center vertical-align text-white "
+                  onClick={() => {
+                    setIsAddContextFiltersModalOpen(true);
+                  }}
+                >
+                  {chatFilters.files.length > 0
+                    ? "Update filters"
+                    : "Add filters"}
+                </button>
+              </div>
+            </>
+          )}
+          {isAddContextFiltersModalOpen && (
+            <AddContextFiltersModal
               vaultDirectory={vaultDirectory}
-              isOpen={isAddContextFiltersModalOpen} onClose={() => setIsAddContextFiltersModalOpen(false)}
+              isOpen={isAddContextFiltersModalOpen}
+              onClose={() => setIsAddContextFiltersModalOpen(false)}
               titleText="You can optionally include a file into chat context"
               chatFilters={chatFilters}
               setChatFilters={setChatFilters}
               maxSuggestionWidth="w-[900px]"
-            />}
+            />
+          )}
           {userTextFieldInput === "" &&
           currentChatHistory?.displayableChatHistory.length == 0 ? (
             <>

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -200,12 +200,12 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
 
   // update chat context when files are added
   useEffect(() => {
-
     const setContextOnFileAdded = async () => {
       if (chatFilters.files.length > 0) {
         const results = await window.files.getFilesystemPathsAsDBItems(chatFilters.files);
         setCurrentContext(results as DBQueryResult[]);
-      } else {
+      } else if (!currentChatHistory?.id) {
+        // if there is no prior history, set current context to empty
         setCurrentContext([]);
       }
     }

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -419,7 +419,8 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
               </div>
               <div className="flex items-center justify-center text-gray-300 text-sm">
                 <button
-                  className="bg-slate-600 m-2 rounded-lg border-none h-6 w-40 text-center vertical-align text-white "
+                  className="bg-slate-600 m-2 rounded-lg border-none 
+                  h-6 w-40 text-center cursor-pointer vertical-align text-white"
                   onClick={() => {
                     setIsAddContextFiltersModalOpen(true);
                   }}
@@ -436,10 +437,9 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
               vaultDirectory={vaultDirectory}
               isOpen={isAddContextFiltersModalOpen}
               onClose={() => setIsAddContextFiltersModalOpen(false)}
-              titleText="You can optionally include a file into chat context"
+              titleText="Add file(s) into chat context"
               chatFilters={chatFilters}
               setChatFilters={setChatFilters}
-              maxSuggestionWidth="w-[900px]"
             />
           )}
           {userTextFieldInput === "" &&

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -26,6 +26,7 @@ import {
 import { useDebounce } from "use-debounce";
 import { SimilarEntriesComponent } from "../Similarity/SimilarFilesSidebar";
 import ResizableComponent from "../Generic/ResizableComponent";
+import AddContextFiltersModal from "./AddContextFiltersModal";
 
 // convert ask options to enum
 enum AskOptions {
@@ -143,6 +144,7 @@ export const resolveRAGContext = async (
       chatFilters.numberOfChunksToFetch
     );
   }
+  console.log("results", results)
   return {
     messageType: "success",
     role: "user",
@@ -155,6 +157,7 @@ export const resolveRAGContext = async (
 };
 
 interface ChatWithLLMProps {
+  vaultDirectory: string;
   openFileByPath: (path: string) => Promise<void>;
 
   setChatHistoriesMetadata: React.Dispatch<
@@ -166,23 +169,30 @@ interface ChatWithLLMProps {
     React.SetStateAction<ChatHistory | undefined>
   >;
   showSimilarFiles: boolean;
+  chatFilters: ChatFilters;
+  setChatFilters: React.Dispatch<ChatFilters>;
 }
 
 const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
+  vaultDirectory,
   openFileByPath,
-
   setChatHistoriesMetadata,
   currentChatHistory,
   setCurrentChatHistory,
   showSimilarFiles,
+  chatFilters,
+  setChatFilters,
 }) => {
   const [userTextFieldInput, setUserTextFieldInput] = useState<string>("");
   const [askText, setAskText] = useState<AskOptions>(AskOptions.Ask);
   const [loadingResponse, setLoadingResponse] = useState<boolean>(false);
-  const [chatFilters, setChatFilters] = useState<ChatFilters>();
   const [readyToSave, setReadyToSave] = useState<boolean>(false);
   const [currentContext, setCurrentContext] = useState<DBQueryResult[]>([]);
+  const [isAddContextFiltersModalOpen, setIsAddContextFiltersModalOpen] = useState<boolean>(false);
 
+  // chat filters related state: this is the only thing that the Chat component cares about
+  // chat component doesn't care about previous states and suggestions, and it can reset it
+  // RESET when a new chat occurs
   useEffect(() => {
     const context = getChatHistoryContext(currentChatHistory);
     setCurrentContext(context);
@@ -210,7 +220,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           displayableChatHistory: [],
         };
       }
-
+      console.log(chatFilters)
       if (chatHistory.displayableChatHistory.length === 0) {
         if (chatFilters) {
           // chatHistory.displayableChatHistory.push({
@@ -233,6 +243,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           context: [],
         });
       }
+      console.log(chatHistory)
 
       setUserTextFieldInput("");
 
@@ -362,7 +373,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
     <div className="flex items-center justify-center w-full h-full">
       <div className="flex flex-col w-full h-full mx-auto overflow-hidden bg-neutral-800 border-l-[0.001px] border-b-0 border-t-0 border-r-0 border-neutral-700 border-solid">
         <div className="flex flex-col overflow-auto p-3 pt-0 bg-transparent h-full">
-          <div className="space-y-2 mt-4 flex-grow">
+          <div className="space-y-2 ml-4 mr-4 flex-grow">
             {currentChatHistory?.displayableChatHistory
               .filter((msg) => msg.role !== "system")
               .map((message, index) => (
@@ -373,8 +384,8 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
                     message.messageType === "error"
                       ? "bg-red-100 text-red-800"
                       : message.role === "assistant"
-                      ? "bg-blue-100 text-blue-800"
-                      : "bg-green-100 text-green-800"
+                      ? "bg-neutral-600	text-gray-200"
+                      : "bg-blue-100	text-blue-800"
                   } `}
                 >
                   {message.visibleContent
@@ -383,6 +394,31 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
                 </ReactMarkdown>
               ))}
           </div>
+          {
+            (!currentChatHistory || currentChatHistory?.displayableChatHistory.length == 0) && (
+              <>
+                <div className="flex items-center justify-center text-gray-300 text-sm">
+                  Start a conversation with your notes by typing a message below.
+                </div>
+                <div className="flex items-center justify-center text-gray-300 text-sm">
+                  <button className='bg-slate-600 m-2 rounded-lg border-none h-6 w-40 text-center vertical-align text-white '
+                      onClick={() => {
+                        setIsAddContextFiltersModalOpen(true)
+                    }}>
+                  {chatFilters.files.length > 0 ? "Update filters" : "Add filters"}
+                  </button>
+                </div>
+              </>
+            )
+          }
+          {isAddContextFiltersModalOpen && <AddContextFiltersModal
+              vaultDirectory={vaultDirectory}
+              isOpen={isAddContextFiltersModalOpen} onClose={() => setIsAddContextFiltersModalOpen(false)}
+              titleText="You can optionally include a file into chat context"
+              chatFilters={chatFilters}
+              setChatFilters={setChatFilters}
+              maxSuggestionWidth="w-[900px]"
+            />}
           {userTextFieldInput === "" &&
           currentChatHistory?.displayableChatHistory.length == 0 ? (
             <>
@@ -408,8 +444,6 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           }
           loadingResponse={loadingResponse}
           askText={askText}
-          chatFilters={chatFilters}
-          setChatFilters={setChatFilters}
         />
       </div>
       {showSimilarFiles && (

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -8,8 +8,6 @@ interface ChatInputProps {
   handleSubmitNewMessage: () => void;
   loadingResponse: boolean;
   askText: string;
-  chatFilters: ChatFilters | undefined;
-  setChatFilters: (chatFilters: ChatFilters) => void;
 }
 
 const ChatInput: React.FC<ChatInputProps> = ({
@@ -18,16 +16,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
   handleSubmitNewMessage,
   loadingResponse,
   askText,
-  chatFilters,
-  setChatFilters,
 }) => {
   return (
     <div className="p-3 bg-neutral-600">
       <div className="flex h-full">
-        <FilterComponent
-          chatFilters={chatFilters}
-          setChatFilters={setChatFilters}
-        />
         <Textarea
           onKeyDown={(e) => {
             if (!e.shiftKey && e.key === "Enter") {
@@ -76,22 +68,3 @@ const ChatInput: React.FC<ChatInputProps> = ({
 };
 
 export default ChatInput;
-
-interface FilterComponentProps {
-  chatFilters: ChatFilters | undefined;
-  setChatFilters: (chatFilters: ChatFilters) => void;
-}
-
-const FilterComponent: React.FC<FilterComponentProps> = ({
-  // chatFilters,
-  setChatFilters,
-}) => {
-  useEffect(() => {
-    setChatFilters({
-      files: [],
-      numberOfChunksToFetch: 15,
-    });
-  }, []);
-
-  return <div className="flex space-x-2"></div>;
-};

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { CircularProgress } from "@mui/material";
 import Textarea from "@mui/joy/Textarea";
-import { ChatFilters } from "./Chat";
 interface ChatInputProps {
   userTextFieldInput: string;
   setUserTextFieldInput: (value: string) => void;

--- a/src/components/Editor/FilesSuggestionsDisplay.tsx
+++ b/src/components/Editor/FilesSuggestionsDisplay.tsx
@@ -1,0 +1,86 @@
+import { removeFileExtension } from "@/functions/strings";
+import React, { useRef, useEffect, useState, useMemo } from "react";
+
+export interface SuggestionsState {
+  textWithinBrackets: string;
+  position: { top: number; left: number };
+  onSelect: (suggestion: string) => void;
+}
+
+interface SuggestionsDisplayProps {
+  suggestionsState: SuggestionsState;
+  suggestions: string[];
+  maxWidth?: string;
+}
+
+const InEditorBacklinkSuggestionsDisplay: React.FC<SuggestionsDisplayProps> = ({
+  suggestionsState,
+  suggestions,
+  maxWidth = "max-w-sm",
+}) => {
+  const suggestionsRef = useRef<HTMLDivElement | null>(null);
+  const [layout, setLayout] = useState({
+    top: -9999,
+    left: -9999,
+    display: "none",
+  });
+
+  const filteredSuggestions = useMemo(() => {
+    if (!suggestionsState.textWithinBrackets) return [];
+    const lowerCaseText = suggestionsState.textWithinBrackets.toLowerCase();
+    return suggestions
+      .filter((suggestion) => suggestion.toLowerCase().includes(lowerCaseText))
+      .map(removeFileExtension)
+      .slice(0, 5);
+  }, [suggestions, suggestionsState.textWithinBrackets]);
+
+  useEffect(() => {
+    if (
+      !suggestionsState.position ||
+      filteredSuggestions.length === 0 ||
+      !suggestionsRef.current
+    ) {
+      return;
+    }
+    const { top, left } = suggestionsState.position;
+    const { height } = suggestionsRef.current.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
+    const shouldDisplayAbove = top + height > viewportHeight && top > height;
+
+    setLayout({
+      top: shouldDisplayAbove ? top - height : top,
+      left: left,
+      display: "block",
+    });
+  }, [suggestionsState.position, filteredSuggestions]);
+
+  if (filteredSuggestions.length === 0) return null;
+
+  return (
+    <div
+      ref={suggestionsRef}
+      className={`absolute rounded bg-white text-black ${maxWidth} border border-black  z-50 break-words whitespace-normal`}
+      style={{
+        left: `${layout.left}px`,
+        top: `${layout.top}px`,
+        display: layout.display,
+      }}
+    >
+      <ul className="m-0 p-0 list-none">
+        {filteredSuggestions.map((suggestion) => (
+          <li
+            key={suggestion} // Use a unique id property from the suggestion
+            className="p-1.25 cursor-pointer hover:bg-gray-100 p-1 text-sm rounded"
+            onClick={() => {
+              suggestionsState.onSelect?.(suggestion);
+            }}
+          >
+            {suggestion}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default InEditorBacklinkSuggestionsDisplay;

--- a/src/components/Editor/FilesSuggestionsDisplay.tsx
+++ b/src/components/Editor/FilesSuggestionsDisplay.tsx
@@ -16,7 +16,7 @@ interface SuggestionsDisplayProps {
 const InEditorBacklinkSuggestionsDisplay: React.FC<SuggestionsDisplayProps> = ({
   suggestionsState,
   suggestions,
-  maxWidth = "max-w-sm",
+  maxWidth,
 }) => {
   const suggestionsRef = useRef<HTMLDivElement | null>(null);
   const [layout, setLayout] = useState({
@@ -56,6 +56,7 @@ const InEditorBacklinkSuggestionsDisplay: React.FC<SuggestionsDisplayProps> = ({
 
   if (filteredSuggestions.length === 0) return null;
 
+  console.log(maxWidth);
   return (
     <div
       ref={suggestionsRef}
@@ -64,13 +65,14 @@ const InEditorBacklinkSuggestionsDisplay: React.FC<SuggestionsDisplayProps> = ({
         left: `${layout.left}px`,
         top: `${layout.top}px`,
         display: layout.display,
+        width: `${maxWidth}px`,
       }}
     >
-      <ul className="m-0 p-0 list-none">
+      <ul className={`m-0 p-0 list-none`}>
         {filteredSuggestions.map((suggestion) => (
           <li
             key={suggestion} // Use a unique id property from the suggestion
-            className="p-1.25 cursor-pointer hover:bg-gray-100 p-1 text-sm rounded"
+            className={`p-1.25 cursor-pointer hover:bg-gray-100 p-1 text-sm rounded break-words`}
             onClick={() => {
               suggestionsState.onSelect?.(suggestion);
             }}

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -66,7 +66,6 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
     numberOfChunksToFetch: 15,
   });
 
-
   // find all available files
   useEffect(() => {
     const setFileDirectory = async () => {
@@ -75,6 +74,23 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
       setVaultDirectory(windowDirectory);
     };
     setFileDirectory();
+  }, []);
+
+  useEffect(() => {
+    const removeAddChatToFileListener = window.ipcRenderer.receive(
+      "add-file-to-chat-listener",
+      (noteName: string) => {
+        setSidebarShowing("chats");
+        setCurrentChatHistory(undefined);
+        setChatFilters({
+        ...chatFilters,
+        files: [...chatFilters.files, noteName],
+      })}
+    );
+
+    return () => {
+      removeAddChatToFileListener();
+    };
   }, []);
 
   return (

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import TitleBar from "./TitleBar";
-import ChatWithLLM, { ChatHistory } from "./Chat/Chat";
+import ChatWithLLM, { ChatFilters, ChatHistory } from "./Chat/Chat";
 import IconsSidebar from "./Sidebars/IconsSidebar";
 import ResizableComponent from "./Generic/ResizableComponent";
 import SidebarManager from "./Sidebars/MainSidebar";
@@ -60,6 +60,23 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
     setCurrentChatHistory(chatHistory);
   };
 
+  const [vaultDirectory, setVaultDirectory] = useState<string>("");
+  const [chatFilters, setChatFilters] = useState<ChatFilters>({
+    files: [],
+    numberOfChunksToFetch: 15,
+  });
+
+
+  // find all available files
+  useEffect(() => {
+    const setFileDirectory = async () => {
+      const windowDirectory =
+        await window.electronStore.getVaultDirectoryForWindow();
+      setVaultDirectory(windowDirectory);
+    };
+    setFileDirectory();
+  }, []);
+
   return (
     <div>
       <TitleBar
@@ -98,6 +115,7 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
               currentChatHistory={currentChatHistory}
               chatHistoriesMetadata={chatHistoriesMetadata}
               setCurrentChatHistory={openChatAndOpenChat}
+              setChatFilters={setChatFilters}
             />
           </div>
         </ResizableComponent>
@@ -144,11 +162,14 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
           <div className={`w-full h-below-titlebar`}>
             {/* <ResizableComponent resizeSide="left" initialWidth={450}> */}
             <ChatWithLLM
+              vaultDirectory={vaultDirectory}
               openFileByPath={openFileAndOpenEditor}
               setChatHistoriesMetadata={setChatHistoriesMetadata}
               currentChatHistory={currentChatHistory}
               setCurrentChatHistory={setCurrentChatHistory}
               showSimilarFiles={showSimilarFiles}
+              chatFilters={chatFilters}
+              setChatFilters={setChatFilters}
             />
             {/* </ResizableComponent> */}
           </div>

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -66,6 +66,15 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
     numberOfChunksToFetch: 15,
   });
 
+  const handleAddFileToChatFilters = (file: string) => {
+    setSidebarShowing("chats");
+    setShowChatbot(true);
+    setCurrentChatHistory(undefined);
+    setChatFilters({
+      ...chatFilters,
+      files: [...chatFilters.files, file]});
+  }
+
   // find all available files
   useEffect(() => {
     const setFileDirectory = async () => {
@@ -80,12 +89,8 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
     const removeAddChatToFileListener = window.ipcRenderer.receive(
       "add-file-to-chat-listener",
       (noteName: string) => {
-        setSidebarShowing("chats");
-        setCurrentChatHistory(undefined);
-        setChatFilters({
-        ...chatFilters,
-        files: [...chatFilters.files, noteName],
-      })}
+        handleAddFileToChatFilters(noteName);
+      }
     );
 
     return () => {

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -72,8 +72,9 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
     setCurrentChatHistory(undefined);
     setChatFilters({
       ...chatFilters,
-      files: [...chatFilters.files, file]});
-  }
+      files: [...chatFilters.files, file],
+    });
+  };
 
   // find all available files
   useEffect(() => {

--- a/src/components/Flashcard/FlashcardCreateModal.tsx
+++ b/src/components/Flashcard/FlashcardCreateModal.tsx
@@ -115,9 +115,9 @@ const FlashcardCreateModal: React.FC<FlashcardCreateModalProps> = ({
             value={searchText}
             onSelect={() => initializeSuggestionsStateOnFocus()}
             onChange={(e) => {
-              setSearchText(e.target.value)
+              setSearchText(e.target.value);
               if (e.target.value.length == 0) {
-                setSelectedFile('')
+                setSelectedFile("");
               }
             }}
             placeholder="Search for the files by name"

--- a/src/components/Flashcard/FlashcardCreateModal.tsx
+++ b/src/components/Flashcard/FlashcardCreateModal.tsx
@@ -164,7 +164,7 @@ const FlashcardCreateModal: React.FC<FlashcardCreateModalProps> = ({
         <div className="flex justify-end">
           {selectedFile && (
             <Button
-              className="bg-slate-900/75 border-none h-20 w-96 text-center vertical-align
+              className="bg-slate-600 border-none h-20 w-96 text-center vertical-align text-white
             mt-4 mr-16
             cursor-pointer
             disabled:pointer-events-none

--- a/src/components/Flashcard/FlashcardMenuModal.tsx
+++ b/src/components/Flashcard/FlashcardMenuModal.tsx
@@ -50,7 +50,7 @@ const FlashcardMenuModal: React.FC<FlashcardMenuModalProps> = ({
         )}
 
         <Button
-          className="bg-slate-900/75 border-none h-20 w-96 text-center
+          className="bg-slate-600 border-none h-20 w-96 text-center
             mt-4 mr-16
             cursor-pointer
             disabled:pointer-events-none

--- a/src/components/Generic/SearchBarWithFilesSuggestion.tsx
+++ b/src/components/Generic/SearchBarWithFilesSuggestion.tsx
@@ -1,16 +1,18 @@
 import React, { useRef } from "react";
 import { useFileInfoTree } from "../File/FileSideBar/hooks/use-file-info-tree";
-import FilesSuggestionsDisplay, { SuggestionsState } from "../Editor/FilesSuggestionsDisplay";
+import FilesSuggestionsDisplay, {
+  SuggestionsState,
+} from "../Editor/FilesSuggestionsDisplay";
 
 interface Props {
-    vaultDirectory: string;
-    titleText: string;
-    searchText: string;
-    setSearchText: (text: string) => void;
-    onSelectSuggestion: (suggestion: string) => void;
-    suggestionsState: SuggestionsState | null;
-    setSuggestionsState: (state: SuggestionsState | null) => void;
-    maxSuggestionWidth?: string;
+  vaultDirectory: string;
+  titleText: string;
+  searchText: string;
+  setSearchText: (text: string) => void;
+  onSelectSuggestion: (suggestion: string) => void;
+  suggestionsState: SuggestionsState | null;
+  setSuggestionsState: (state: SuggestionsState | null) => void;
+  maxSuggestionWidth?: string;
 }
 
 export const SearchBarWithFilesSuggestion = ({
@@ -22,8 +24,7 @@ export const SearchBarWithFilesSuggestion = ({
   suggestionsState,
   setSuggestionsState,
   maxSuggestionWidth,
-  }: Props) => {
-
+}: Props) => {
   const { flattenedFiles } = useFileInfoTree(vaultDirectory);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -43,9 +44,9 @@ export const SearchBarWithFilesSuggestion = ({
     });
   };
 
-    return (
-        <>
-        <h2 className="text-xl font-semibold mb-3 text-white">
+  return (
+    <>
+      <h2 className="text-xl font-semibold mb-3 text-white">
         {titleText}
         <input
           ref={inputRef}
@@ -56,9 +57,9 @@ export const SearchBarWithFilesSuggestion = ({
           value={searchText}
           onSelect={() => initializeSuggestionsStateOnFocus()}
           onChange={(e) => {
-            setSearchText(e.target.value)
+            setSearchText(e.target.value);
             if (e.target.value.length == 0) {
-              onSelectSuggestion('')
+              onSelectSuggestion("");
             }
           }}
           placeholder="Search for the files by name"
@@ -71,11 +72,11 @@ export const SearchBarWithFilesSuggestion = ({
           />
         )}
       </h2>
-        {!searchText && (
-          <p className="text-red-500 text-xs">
+      {!searchText && (
+        <p className="text-red-500 text-xs">
           Choose a file by searching or by right clicking a file in directory
-          </p>
-        )}
-        </>
-    )
+        </p>
+      )}
+    </>
+  );
 };

--- a/src/components/Generic/SearchBarWithFilesSuggestion.tsx
+++ b/src/components/Generic/SearchBarWithFilesSuggestion.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useFileInfoTree } from "../File/FileSideBar/hooks/use-file-info-tree";
 import FilesSuggestionsDisplay, {
   SuggestionsState,
@@ -12,7 +12,6 @@ interface Props {
   onSelectSuggestion: (suggestion: string) => void;
   suggestionsState: SuggestionsState | null;
   setSuggestionsState: (state: SuggestionsState | null) => void;
-  maxSuggestionWidth?: string;
 }
 
 export const SearchBarWithFilesSuggestion = ({
@@ -23,7 +22,6 @@ export const SearchBarWithFilesSuggestion = ({
   onSelectSuggestion,
   suggestionsState,
   setSuggestionsState,
-  maxSuggestionWidth,
 }: Props) => {
   const { flattenedFiles } = useFileInfoTree(vaultDirectory);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -43,6 +41,27 @@ export const SearchBarWithFilesSuggestion = ({
       onSelect: (suggestion) => onSelectSuggestion(suggestion),
     });
   };
+
+  console.log(inputRef.current?.offsetWidth);
+
+  const [sidebarWidth, setSidebarWidth] = useState(0);
+
+  useEffect(() => {
+    // Calculate the width of the sidebar
+    const calculateWidth = () => {
+      if (inputRef.current) {
+        setSidebarWidth(inputRef.current.offsetWidth);
+      }
+      console.log("sidebar width : ", inputRef.current?.offsetWidth);
+    };
+
+    // Update width on mount and window resize
+    calculateWidth();
+    window.addEventListener("resize", calculateWidth);
+
+    // Cleanup event listener
+    return () => window.removeEventListener("resize", calculateWidth);
+  });
 
   return (
     <>
@@ -68,7 +87,7 @@ export const SearchBarWithFilesSuggestion = ({
           <FilesSuggestionsDisplay
             suggestionsState={suggestionsState}
             suggestions={flattenedFiles.map((file) => file.path)}
-            maxWidth={maxSuggestionWidth}
+            maxWidth={`${sidebarWidth}`}
           />
         )}
       </h2>

--- a/src/components/Generic/SearchBarWithFilesSuggestion.tsx
+++ b/src/components/Generic/SearchBarWithFilesSuggestion.tsx
@@ -1,0 +1,81 @@
+import React, { useRef } from "react";
+import { useFileInfoTree } from "../File/FileSideBar/hooks/use-file-info-tree";
+import FilesSuggestionsDisplay, { SuggestionsState } from "../Editor/FilesSuggestionsDisplay";
+
+interface Props {
+    vaultDirectory: string;
+    titleText: string;
+    searchText: string;
+    setSearchText: (text: string) => void;
+    onSelectSuggestion: (suggestion: string) => void;
+    suggestionsState: SuggestionsState | null;
+    setSuggestionsState: (state: SuggestionsState | null) => void;
+    maxSuggestionWidth?: string;
+}
+
+export const SearchBarWithFilesSuggestion = ({
+  vaultDirectory,
+  titleText,
+  searchText,
+  setSearchText,
+  onSelectSuggestion,
+  suggestionsState,
+  setSuggestionsState,
+  maxSuggestionWidth,
+  }: Props) => {
+
+  const { flattenedFiles } = useFileInfoTree(vaultDirectory);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const initializeSuggestionsStateOnFocus = () => {
+    const inputCoords = inputRef.current?.getBoundingClientRect();
+    if (!inputCoords) {
+      return;
+    }
+
+    setSuggestionsState({
+      position: {
+        top: inputCoords.bottom,
+        left: inputCoords.x,
+      },
+      textWithinBrackets: searchText,
+      onSelect: (suggestion) => onSelectSuggestion(suggestion),
+    });
+  };
+
+    return (
+        <>
+        <h2 className="text-xl font-semibold mb-3 text-white">
+        {titleText}
+        <input
+          ref={inputRef}
+          type="text"
+          className="block w-full px-3 py-2 mt-6 h-[40px] border border-gray-300 box-border rounded-md
+          focus:outline-none focus:shadow-outline-blue focus:border-blue-300
+          transition duration-150 ease-in-out"
+          value={searchText}
+          onSelect={() => initializeSuggestionsStateOnFocus()}
+          onChange={(e) => {
+            setSearchText(e.target.value)
+            if (e.target.value.length == 0) {
+              onSelectSuggestion('')
+            }
+          }}
+          placeholder="Search for the files by name"
+        />
+        {suggestionsState && (
+          <FilesSuggestionsDisplay
+            suggestionsState={suggestionsState}
+            suggestions={flattenedFiles.map((file) => file.path)}
+            maxWidth={maxSuggestionWidth}
+          />
+        )}
+      </h2>
+        {!searchText && (
+          <p className="text-red-500 text-xs">
+          Choose a file by searching or by right clicking a file in directory
+          </p>
+        )}
+        </>
+    )
+};

--- a/src/components/Sidebars/MainSidebar.tsx
+++ b/src/components/Sidebars/MainSidebar.tsx
@@ -5,7 +5,7 @@ import { DBQueryResult } from "electron/main/database/Schema";
 import { FileInfoTree } from "electron/main/Files/Types";
 import { ChatsSidebar } from "../Chat/ChatsSidebar";
 import { SidebarAbleToShow } from "../FileEditorContainer";
-import { ChatHistory } from "../Chat/Chat";
+import { ChatFilters, ChatHistory } from "../Chat/Chat";
 import { ChatHistoryMetadata } from "../Chat/hooks/use-chat-history";
 
 interface SidebarManagerProps {
@@ -23,6 +23,7 @@ interface SidebarManagerProps {
   currentChatHistory: ChatHistory | undefined;
   chatHistoriesMetadata: ChatHistoryMetadata[];
   setCurrentChatHistory: (chat: ChatHistory | undefined) => void;
+  setChatFilters: (chatFilters: ChatFilters) => void;
 }
 
 const SidebarManager: React.FC<SidebarManagerProps> = ({
@@ -40,6 +41,7 @@ const SidebarManager: React.FC<SidebarManagerProps> = ({
   currentChatHistory,
   chatHistoriesMetadata,
   setCurrentChatHistory,
+  setChatFilters,
 }) => {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [searchResults, setSearchResults] = useState<DBQueryResult[]>([]);
@@ -81,6 +83,10 @@ const SidebarManager: React.FC<SidebarManagerProps> = ({
           }}
           newChat={() => {
             setCurrentChatHistory(undefined);
+            setChatFilters({
+              files: [],
+              numberOfChunksToFetch: 15,
+            });
           }}
         />
       )}

--- a/src/components/Similarity/SimilarFilesSidebar.tsx
+++ b/src/components/Similarity/SimilarFilesSidebar.tsx
@@ -228,7 +228,7 @@ export const SimilarEntriesComponent: React.FC<
                   updateSimilarEntries(!isRefined);
                 }}
               >
-                {isRefined ? "Unrefine" : "Refine results"}
+                {isRefined ? "Un-rerank" : "Rerank results"}
               </button>
             )}
           </div>

--- a/src/components/Similarity/SimilarFilesSidebar.tsx
+++ b/src/components/Similarity/SimilarFilesSidebar.tsx
@@ -179,7 +179,6 @@ export const SimilarEntriesComponent: React.FC<
   titleText,
   isLoadingSimilarEntries,
 }) => {
-
   return (
     <div>
       <ResizableComponent resizeSide="left" initialWidth={300}>

--- a/src/components/Similarity/SimilarFilesSidebar.tsx
+++ b/src/components/Similarity/SimilarFilesSidebar.tsx
@@ -179,6 +179,7 @@ export const SimilarEntriesComponent: React.FC<
   titleText,
   isLoadingSimilarEntries,
 }) => {
+
   return (
     <div>
       <ResizableComponent resizeSide="left" initialWidth={300}>


### PR DESCRIPTION
This PR adds:
1. Ability to add file filters and have them show up in the sidebar
2. Have the file filters show up as list in the modal
3. Resetting chat history and context when new chat is created
4. Updated Chat history colors to be less loud
5. Display files selected as context on the side bar to allow users to know that the file was successfully attached


Further work:
1. Doesnt handle the situation where files are out of context because its too long
2. Doesn't handle deleting files in the modal, but you can reset the chat for now by either leaving chat mode or hitting the `+ New chat` button