### PR TITLE
Allow users to delete their chat histories

### DIFF
--- a/electron/main/Store/storeHandlers.ts
+++ b/electron/main/Store/storeHandlers.ts
@@ -198,6 +198,38 @@ export const registerStoreHandlers = (
     const vaultChatHistories = allChatHistories[vaultDir] || [];
     return vaultChatHistories.find((chat) => chat.id === chatId);
   });
+
+  ipcMain.handle("update-all-chat-history", (event, chatID: string) => {
+    const vaultDir = windowsManager.getVaultDirectoryForWinContents(
+      event.sender
+    );
+
+    if (!vaultDir) {
+      return;
+    }
+
+    const chatHistoriesMap = store.get(StoreKeys.ChatHistories);
+    const allChatHistories = chatHistoriesMap[vaultDir] || [];
+    // console.log(`Chat histories map: ${JSON.stringify(allChatHistories)}`);
+    const filteredChatHistories = allChatHistories.filter(item => item.id !== chatID);
+    store.set(StoreKeys.ChatHistories, filteredChatHistories);
+  });
+
+  ipcMain.handle("remove-chat-history-at-id", (event, chatID: string) => {
+    const vaultDir = windowsManager.getVaultDirectoryForWinContents(
+      event.sender
+    );
+
+    if (!vaultDir) {
+      return;
+    }
+
+    const chatHistoriesMap = store.get(StoreKeys.ChatHistories);
+    const allChatHistories = chatHistoriesMap[vaultDir] || [];
+    const filteredChatHistories = allChatHistories.filter(item => item.id !== chatID);
+    chatHistoriesMap[vaultDir] = filteredChatHistories;
+    store.set(StoreKeys.ChatHistories, chatHistoriesMap);
+  });
 };
 
 export function getDefaultEmbeddingModelConfig(

--- a/electron/main/Store/storeHandlers.ts
+++ b/electron/main/Store/storeHandlers.ts
@@ -185,6 +185,11 @@ export const registerStoreHandlers = (
       ...allChatHistories,
       [vaultDir]: chatHistoriesCorrespondingToVault,
     });
+
+    event.sender.send(
+      "update-chat-histories",
+      chatHistoriesCorrespondingToVault
+    );
   });
 
   ipcMain.handle("get-chat-history", (event, chatId: string) => {
@@ -199,22 +204,6 @@ export const registerStoreHandlers = (
     return vaultChatHistories.find((chat) => chat.id === chatId);
   });
 
-  ipcMain.handle("update-all-chat-history", (event, chatID: string) => {
-    const vaultDir = windowsManager.getVaultDirectoryForWinContents(
-      event.sender
-    );
-
-    if (!vaultDir) {
-      return;
-    }
-
-    const chatHistoriesMap = store.get(StoreKeys.ChatHistories);
-    const allChatHistories = chatHistoriesMap[vaultDir] || [];
-    // console.log(`Chat histories map: ${JSON.stringify(allChatHistories)}`);
-    const filteredChatHistories = allChatHistories.filter(item => item.id !== chatID);
-    store.set(StoreKeys.ChatHistories, filteredChatHistories);
-  });
-
   ipcMain.handle("remove-chat-history-at-id", (event, chatID: string) => {
     const vaultDir = windowsManager.getVaultDirectoryForWinContents(
       event.sender
@@ -226,7 +215,9 @@ export const registerStoreHandlers = (
 
     const chatHistoriesMap = store.get(StoreKeys.ChatHistories);
     const allChatHistories = chatHistoriesMap[vaultDir] || [];
-    const filteredChatHistories = allChatHistories.filter(item => item.id !== chatID);
+    const filteredChatHistories = allChatHistories.filter(
+      (item) => item.id !== chatID
+    );
     chatHistoriesMap[vaultDir] = filteredChatHistories.reverse();
     store.set(StoreKeys.ChatHistories, chatHistoriesMap);
   });

--- a/electron/main/Store/storeHandlers.ts
+++ b/electron/main/Store/storeHandlers.ts
@@ -227,7 +227,7 @@ export const registerStoreHandlers = (
     const chatHistoriesMap = store.get(StoreKeys.ChatHistories);
     const allChatHistories = chatHistoriesMap[vaultDir] || [];
     const filteredChatHistories = allChatHistories.filter(item => item.id !== chatID);
-    chatHistoriesMap[vaultDir] = filteredChatHistories;
+    chatHistoriesMap[vaultDir] = filteredChatHistories.reverse();
     store.set(StoreKeys.ChatHistories, chatHistoriesMap);
   });
 };

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -216,6 +216,23 @@ ipcMain.handle("show-context-menu-file-item", (event, file) => {
   }
 });
 
+ipcMain.handle("show-chat-menu-item", (event, chatID) => {
+  const menu = new Menu();
+
+  menu.append(
+    new MenuItem({
+      label: "Delete Chat",
+      click: () => {
+        event.sender.send("remove-chat-at-id", chatID);
+      },
+    })
+  );
+
+  const browserWindow = BrowserWindow.fromWebContents(event.sender);
+  if (browserWindow)
+    menu.popup({ window: browserWindow })
+});
+
 ipcMain.handle("open-external", (event, url) => {
   shell.openExternal(url);
 });

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -154,7 +154,7 @@ declare global {
       getAllChatHistories: () => Promise<ChatHistory[]>;
       updateChatHistory: (chatHistory: ChatHistory) => void;
       getChatHistory: (chatID: string) => Promise<ChatHistory>;
-      updateAllChatHistories: (chatID: string) => void;
+      removeChatHistoryAtID: (chatID: string) => void;
     };
   }
 }
@@ -294,7 +294,7 @@ contextBridge.exposeInMainWorld("electronStore", {
   updateChatHistory: (chatHistory: ChatHistory) => {
     ipcRenderer.invoke("update-chat-history", chatHistory);
   },
-  updateAllChatHistories: (chatID: string) => {
+  removeChatHistoryAtID: (chatID: string) => {
     ipcRenderer.invoke("remove-chat-history-at-id", chatID);
   },
   getChatHistory: (chatID: string) => {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -19,6 +19,7 @@ import { PromptWithContextLimit } from "electron/main/Prompts/Prompts";
 import { PromptWithRagResults } from "electron/main/database/dbSessionHandlers";
 import { BasePromptRequirements } from "electron/main/database/dbSessionHandlerTypes";
 import { ChatHistory } from "@/components/Chat/Chat";
+import { ChatHistoryMetadata } from "@/components/Chat/hooks/use-chat-history";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ReceiveCallback = (...args: any[]) => void;
 
@@ -35,6 +36,9 @@ declare global {
     };
     contextMenu: {
       showFileItemContextMenu: (filePath: FileInfoNode) => void;
+    };
+    contextChatMenu: {
+      showChatItemContext: (chatRow: ChatHistoryMetadata) => void;
     };
     database: {
       search: (
@@ -150,6 +154,7 @@ declare global {
       getAllChatHistories: () => Promise<ChatHistory[]>;
       updateChatHistory: (chatHistory: ChatHistory) => void;
       getChatHistory: (chatID: string) => Promise<ChatHistory>;
+      updateAllChatHistories: (chatID: string) => void;
     };
   }
 }
@@ -289,6 +294,9 @@ contextBridge.exposeInMainWorld("electronStore", {
   updateChatHistory: (chatHistory: ChatHistory) => {
     ipcRenderer.invoke("update-chat-history", chatHistory);
   },
+  updateAllChatHistories: (chatID: string) => {
+    ipcRenderer.invoke("remove-chat-history-at-id", chatID);
+  },
   getChatHistory: (chatID: string) => {
     return ipcRenderer.invoke("get-chat-history", chatID);
   },
@@ -311,6 +319,12 @@ contextBridge.exposeInMainWorld("ipcRenderer", {
 contextBridge.exposeInMainWorld("contextMenu", {
   showFileItemContextMenu: (file: FileInfoNode) => {
     ipcRenderer.invoke("show-context-menu-file-item", file);
+  },
+});
+
+contextBridge.exposeInMainWorld("contextChatMenu", {
+  showChatItemContext: (chatRow: ChatHistoryMetadata) => {
+    ipcRenderer.invoke("show-chat-menu-item", chatRow.id);
   },
 });
 

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -161,10 +161,6 @@ interface ChatWithLLMProps {
   vaultDirectory: string;
   openFileByPath: (path: string) => Promise<void>;
 
-  setChatHistoriesMetadata: React.Dispatch<
-    React.SetStateAction<ChatHistoryMetadata[]>
-  >;
-  // setAllChatHistories: React.Dispatch<React.SetStateAction<ChatHistory[]>>;
   currentChatHistory: ChatHistory | undefined;
   setCurrentChatHistory: React.Dispatch<
     React.SetStateAction<ChatHistory | undefined>
@@ -177,7 +173,6 @@ interface ChatWithLLMProps {
 const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
   vaultDirectory,
   openFileByPath,
-  setChatHistoriesMetadata,
   currentChatHistory,
   setCurrentChatHistory,
   showSimilarFiles,
@@ -268,27 +263,6 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
       setUserTextFieldInput("");
 
       setCurrentChatHistory(chatHistory);
-      setChatHistoriesMetadata((prev) => {
-        if (!chatHistory) return prev;
-        if (prev?.find((chat) => chat.id === chatHistory?.id)) {
-          return prev;
-        }
-        const newChatHistories = prev
-          ? [
-              ...prev,
-              {
-                id: chatHistory.id,
-                displayName: getDisplayableChatName(chatHistory),
-              },
-            ]
-          : [
-              {
-                id: chatHistory.id,
-                displayName: getDisplayableChatName(chatHistory),
-              },
-            ];
-        return newChatHistories;
-      });
 
       if (!chatHistory) return;
 

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -242,7 +242,6 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           displayableChatHistory: [],
         };
       }
-      console.log(chatFilters);
       if (chatHistory.displayableChatHistory.length === 0) {
         if (chatFilters) {
           // chatHistory.displayableChatHistory.push({
@@ -265,7 +264,6 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
           context: [],
         });
       }
-      console.log(chatHistory);
 
       setUserTextFieldInput("");
 
@@ -495,8 +493,6 @@ const getChatHistoryContext = (
   chatHistory: ChatHistory | undefined
 ): DBQueryResult[] => {
   if (!chatHistory) return [];
-  console.log("chatHistory", chatHistory.displayableChatHistory);
-
   const contextForChat = chatHistory.displayableChatHistory
     .map((message) => {
       return message.context;

--- a/src/components/Chat/ChatsSidebar.tsx
+++ b/src/components/Chat/ChatsSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { ChatHistory } from "./Chat";
 import { ChatHistoryMetadata } from "./hooks/use-chat-history";
 
@@ -8,7 +8,6 @@ interface ChatListProps {
   currentChatHistory: ChatHistory | undefined;
   onSelect: (chatID: string) => void;
   newChat: () => void;
-  setChatHistoriesMetadata: (chat: ChatHistoryMetadata[]) => void;
   setShowChatbot: (showChat: boolean) => void;
 }
 
@@ -17,32 +16,30 @@ export const ChatsSidebar: React.FC<ChatListProps> = ({
   currentChatHistory,
   onSelect,
   newChat,
-  setChatHistoriesMetadata,
   setShowChatbot,
 }) => {
-  const [reversedChatHistoriesMetadata, setReversedChatHistoriesMetadata] =
-    useState<ChatHistoryMetadata[]>([]);
-  useEffect(() => {
-    setReversedChatHistoriesMetadata(chatHistoriesMetadata.reverse());
-  }, [chatHistoriesMetadata]);
   const currentSelectedChatID = useRef<string | undefined>();
-
+  useEffect(() => {
+    console.log("chatHistoriesMetadata", chatHistoriesMetadata);
+  }, [chatHistoriesMetadata]);
   useEffect(() => {
     const deleteChatRow = window.ipcRenderer.receive(
       "remove-chat-at-id",
       (chatID) => {
-        const filteredData = chatHistoriesMetadata.filter(item => item.id !== chatID)
-        setChatHistoriesMetadata(filteredData.reverse());
+        // const filteredData = chatHistoriesMetadata.filter(
+        //   (item) => item.id !== chatID
+        // );
+        // setChatHistoriesMetadata(filteredData.reverse());
         if (chatID === currentSelectedChatID.current) {
-          setShowChatbot(false);  
+          setShowChatbot(false);
         }
-        window.electronStore.updateAllChatHistories(chatID);
+        window.electronStore.removeChatHistoryAtID(chatID);
       }
     );
 
     return () => {
       deleteChatRow();
-    }
+    };
   }, [chatHistoriesMetadata]);
 
   return (
@@ -54,16 +51,19 @@ export const ChatsSidebar: React.FC<ChatListProps> = ({
         <span className="text-sm"> + New Chat</span>
       </div>
 
-      {reversedChatHistoriesMetadata.map((chatMetadata) => (
-        <ChatItem
-          key={chatMetadata.id}
-          // chat={chat}
-          chatMetadata={chatMetadata}
-          selectedChatID={currentChatHistory?.id || ""}
-          onChatSelect={onSelect}
-          currentSelectedChatID={currentSelectedChatID}
-        />
-      ))}
+      {chatHistoriesMetadata
+        .slice()
+        .reverse()
+        .map((chatMetadata) => (
+          <ChatItem
+            key={chatMetadata.id}
+            // chat={chat}
+            chatMetadata={chatMetadata}
+            selectedChatID={currentChatHistory?.id || ""}
+            onChatSelect={onSelect}
+            currentSelectedChatID={currentSelectedChatID}
+          />
+        ))}
     </div>
   );
 };

--- a/src/components/Chat/hooks/use-chat-history.ts
+++ b/src/components/Chat/hooks/use-chat-history.ts
@@ -11,14 +11,14 @@ export const useChatHistory = () => {
   const [chatHistoriesMetadata, setChatHistoriesMetadata] = useState<
     ChatHistoryMetadata[]
   >([]);
-  const [allChatHistories, setAllChatHistories] = useState<ChatHistory[]>([]);
+  // const [chatHistories, setChatHistories] = useState<ChatHistory[]>([]);
 
   const fetchChatHistories = async () => {
     let allChatHistories = await window.electronStore.getAllChatHistories();
     if (!allChatHistories) {
       allChatHistories = [];
     }
-    setAllChatHistories(allChatHistories);
+    // setAllChatHistories(allChatHistories);
     setChatHistoriesMetadata(
       allChatHistories.map((chat) => ({
         id: chat.id,
@@ -30,16 +30,31 @@ export const useChatHistory = () => {
   };
 
   useEffect(() => {
+    const updateChatHistoriesMetadata = window.ipcRenderer.receive(
+      "update-chat-histories",
+      (chatHistoriesMetadata: ChatHistory[]) => {
+        setChatHistoriesMetadata(
+          chatHistoriesMetadata.map((chat: ChatHistory) => ({
+            id: chat.id,
+            displayName: getDisplayableChatName(chat),
+          }))
+        );
+      }
+    );
+
+    return () => {
+      updateChatHistoriesMetadata();
+    };
+  }, []);
+
+  useEffect(() => {
     fetchChatHistories();
   }, []);
 
   return {
-    allChatHistories,
-    setAllChatHistories,
     currentChatHistory,
     setCurrentChatHistory,
     chatHistoriesMetadata,
-    setChatHistoriesMetadata,
   };
 };
 

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -144,6 +144,7 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
               setChatHistoriesMetadata={setChatHistoriesMetadata}
               setCurrentChatHistory={openChatAndOpenChat}
               setChatFilters={setChatFilters}
+              setShowChatbot={setShowChatbot}
             />
           </div>
         </ResizableComponent>

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -141,6 +141,7 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
               setFileDirToBeRenamed={setFileDirToBeRenamed}
               currentChatHistory={currentChatHistory}
               chatHistoriesMetadata={chatHistoriesMetadata}
+              setChatHistoriesMetadata={setChatHistoriesMetadata}
               setCurrentChatHistory={openChatAndOpenChat}
               setChatFilters={setChatFilters}
             />

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -37,12 +37,8 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
     setNavigationHistory,
   } = useFileByFilepath();
 
-  const {
-    currentChatHistory,
-    setCurrentChatHistory,
-    chatHistoriesMetadata,
-    setChatHistoriesMetadata,
-  } = useChatHistory();
+  const { currentChatHistory, setCurrentChatHistory, chatHistoriesMetadata } =
+    useChatHistory();
 
   const { files, flattenedFiles, expandedDirectories, handleDirectoryToggle } =
     useFileInfoTree(filePath);
@@ -141,7 +137,6 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
               setFileDirToBeRenamed={setFileDirToBeRenamed}
               currentChatHistory={currentChatHistory}
               chatHistoriesMetadata={chatHistoriesMetadata}
-              setChatHistoriesMetadata={setChatHistoriesMetadata}
               setCurrentChatHistory={openChatAndOpenChat}
               setChatFilters={setChatFilters}
               setShowChatbot={setShowChatbot}
@@ -193,7 +188,6 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
             <ChatWithLLM
               vaultDirectory={vaultDirectory}
               openFileByPath={openFileAndOpenEditor}
-              setChatHistoriesMetadata={setChatHistoriesMetadata}
               currentChatHistory={currentChatHistory}
               setCurrentChatHistory={setCurrentChatHistory}
               showSimilarFiles={showSimilarFiles}

--- a/src/components/Sidebars/MainSidebar.tsx
+++ b/src/components/Sidebars/MainSidebar.tsx
@@ -7,7 +7,8 @@ import { ChatsSidebar } from "../Chat/ChatsSidebar";
 import { SidebarAbleToShow } from "../FileEditorContainer";
 import { ChatFilters, ChatHistory } from "../Chat/Chat";
 import { ChatHistoryMetadata } from "../Chat/hooks/use-chat-history";
-import posthog from "posthog-js";
+import posthog from "posthog-js"
+
 interface SidebarManagerProps {
   files: FileInfoTree;
   expandedDirectories: Map<string, boolean>;
@@ -23,8 +24,9 @@ interface SidebarManagerProps {
   currentChatHistory: ChatHistory | undefined;
   chatHistoriesMetadata: ChatHistoryMetadata[];
   setCurrentChatHistory: (chat: ChatHistory | undefined) => void;
-  setChatFilters: (chatFilters: ChatFilters) => void;
   setChatHistoriesMetadata: (chat: ChatHistoryMetadata[]) => void;
+  setChatFilters: (chatFilters: ChatFilters) => void;
+  setShowChatbot: (showChat: boolean) => void;
 }
 
 const SidebarManager: React.FC<SidebarManagerProps> = ({
@@ -44,6 +46,7 @@ const SidebarManager: React.FC<SidebarManagerProps> = ({
   setChatHistoriesMetadata,
   setCurrentChatHistory,
   setChatFilters,
+  setShowChatbot
 }) => {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [searchResults, setSearchResults] = useState<DBQueryResult[]>([]);
@@ -92,6 +95,7 @@ const SidebarManager: React.FC<SidebarManagerProps> = ({
             });
           }}
           setChatHistoriesMetadata={setChatHistoriesMetadata}
+          setShowChatbot={setShowChatbot}
         />
       )}
     </div>

--- a/src/components/Sidebars/MainSidebar.tsx
+++ b/src/components/Sidebars/MainSidebar.tsx
@@ -24,6 +24,7 @@ interface SidebarManagerProps {
   chatHistoriesMetadata: ChatHistoryMetadata[];
   setCurrentChatHistory: (chat: ChatHistory | undefined) => void;
   setChatFilters: (chatFilters: ChatFilters) => void;
+  setChatHistoriesMetadata: (chat: ChatHistoryMetadata[]) => void;
 }
 
 const SidebarManager: React.FC<SidebarManagerProps> = ({
@@ -40,6 +41,7 @@ const SidebarManager: React.FC<SidebarManagerProps> = ({
   setFileDirToBeRenamed,
   currentChatHistory,
   chatHistoriesMetadata,
+  setChatHistoriesMetadata,
   setCurrentChatHistory,
   setChatFilters,
 }) => {
@@ -89,6 +91,7 @@ const SidebarManager: React.FC<SidebarManagerProps> = ({
               numberOfChunksToFetch: 15,
             });
           }}
+          setChatHistoriesMetadata={setChatHistoriesMetadata}
         />
       )}
     </div>

--- a/src/components/Sidebars/MainSidebar.tsx
+++ b/src/components/Sidebars/MainSidebar.tsx
@@ -7,7 +7,7 @@ import { ChatsSidebar } from "../Chat/ChatsSidebar";
 import { SidebarAbleToShow } from "../FileEditorContainer";
 import { ChatFilters, ChatHistory } from "../Chat/Chat";
 import { ChatHistoryMetadata } from "../Chat/hooks/use-chat-history";
-import posthog from "posthog-js"
+import posthog from "posthog-js";
 
 interface SidebarManagerProps {
   files: FileInfoTree;
@@ -24,7 +24,6 @@ interface SidebarManagerProps {
   currentChatHistory: ChatHistory | undefined;
   chatHistoriesMetadata: ChatHistoryMetadata[];
   setCurrentChatHistory: (chat: ChatHistory | undefined) => void;
-  setChatHistoriesMetadata: (chat: ChatHistoryMetadata[]) => void;
   setChatFilters: (chatFilters: ChatFilters) => void;
   setShowChatbot: (showChat: boolean) => void;
 }
@@ -43,10 +42,9 @@ const SidebarManager: React.FC<SidebarManagerProps> = ({
   setFileDirToBeRenamed,
   currentChatHistory,
   chatHistoriesMetadata,
-  setChatHistoriesMetadata,
   setCurrentChatHistory,
   setChatFilters,
-  setShowChatbot
+  setShowChatbot,
 }) => {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [searchResults, setSearchResults] = useState<DBQueryResult[]>([]);
@@ -94,7 +92,6 @@ const SidebarManager: React.FC<SidebarManagerProps> = ({
               numberOfChunksToFetch: 15,
             });
           }}
-          setChatHistoriesMetadata={setChatHistoriesMetadata}
           setShowChatbot={setShowChatbot}
         />
       )}


### PR DESCRIPTION
Right now there is no way to delete chat histories. The following PR allows users to:

- Permanently remove a chat in their history
- If they are currently viewing the chat and delete it, then setViewChat to false.
- If they are viewing a chat and delete another chat, then continue viewing the current.

Closes #245 