### PR TITLE
Added a confirmation dialog to prevent accidental file deletions

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -173,8 +173,19 @@ ipcMain.handle("show-context-menu-file-item", (event, file) => {
     new MenuItem({
       label: "Delete",
       click: () => {
-        console.log(file.path);
-        event.sender.send("delete-file-listener", file.path);
+        return dialog
+          .showMessageBox({
+            type: "question",
+            title: "Delete File",
+            message: `Are you sure you want to delete "${file.name}"?`,
+            buttons: ["Yes", "No"],
+          })
+          .then((confirm) => {
+            if (confirm.response === 0) {
+              console.log(file.path);
+              event.sender.send("delete-file-listener", file.path);
+            }
+          });
       },
     })
   );


### PR DESCRIPTION

As a first-time user of reor, I accidentally deleted a whole folder of important documents. To prevent this from happening to other users, I have added a confirmation dialog that prompts the user to confirm their action before a file is deleted.

---

Can probably add a checkbox to the delete confirmation dialog similar to the one in Obsidian.

<img width="771" alt="Screenshot 2024-05-17 at 8 49 42 AM" src="https://github.com/reorproject/reor/assets/15358452/0b4693d7-43a4-4b66-9710-77d138f75d80">

            checkboxLabel: "Don't ask again",
            checkboxChecked: false,
