### PR TITLE
Bug fixes

### DIFF
--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -56,10 +56,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
           onSelectSuggestion={(file: string) => {
             if (file && !internalFilesSelected.includes(file)) {
               //TODO: add markdown extension properly
-              setInternalFilesSelected([
-                ...internalFilesSelected,
-                file + ".md",
-              ]);
+              setInternalFilesSelected([...internalFilesSelected, file]);
             }
             setSuggestionsState(null);
           }}

--- a/src/components/Chat/AddContextFiltersModal.tsx
+++ b/src/components/Chat/AddContextFiltersModal.tsx
@@ -36,7 +36,7 @@ const AddContextFiltersModal: React.FC<Props> = ({
     const currentChatFilters: ChatFilters = chatFilters
       ? {
           ...chatFilters,
-          files: [...chatFilters.files, ...files],
+          files: [...new Set([...chatFilters.files, ...files])],
         }
       : {
           numberOfChunksToFetch: 15,

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -232,6 +232,7 @@ const ChatWithLLM: React.FC<ChatWithLLMProps> = ({
     });
     try {
       if (loadingResponse) return;
+      setLoadingResponse(true);
       if (!userTextFieldInput.trim()) return;
       const defaultLLMName = await window.llm.getDefaultLLMName();
 

--- a/src/components/FileEditorContainer.tsx
+++ b/src/components/FileEditorContainer.tsx
@@ -68,14 +68,13 @@ const FileEditorContainer: React.FC<FileEditorContainerProps> = () => {
   });
 
   const handleAddFileToChatFilters = (file: string) => {
-    const files = [...chatFilters.files, file];
     setSidebarShowing("chats");
     setShowChatbot(true);
     setCurrentChatHistory(undefined);
-    setChatFilters({
-      ...chatFilters,
-      files: files,
-    });
+    setChatFilters((prevChatFilters) => ({
+      ...prevChatFilters,
+      files: [...prevChatFilters.files, file],
+    }));
     posthog.capture("add_file_to_chat", {
       chatFilesLength: files.length,
     });

--- a/src/components/Generic/SearchBarWithFilesSuggestion.tsx
+++ b/src/components/Generic/SearchBarWithFilesSuggestion.tsx
@@ -38,7 +38,7 @@ export const SearchBarWithFilesSuggestion = ({
         left: inputCoords.x,
       },
       textWithinBrackets: searchText,
-      onSelect: (suggestion) => onSelectSuggestion(suggestion),
+      onSelect: (suggestion) => onSelectSuggestion(suggestion + ".md"),
     });
   };
 


### PR DESCRIPTION
1. In Chat.tsx, `handleSubmitNewMessage` loadingResponse variable is never set to true

2. When manually adding files to the chat context, pressing the "Add to context" button adds the current files already shown in the context in AddContextFiltersModal.tsx again, i.e it will be duplicated. -> Use a set to remove duplicates from `chatFilters.files`

3. When adding files to the chat context by right clicking the file and selecting "Add file to chat context", the `setChatFilters` does not update the state correctly, leading to always only 1 file in the chat context, even if you try to add multiple files to the chat context. -> Changed `setChatFilters` the functional update form for useState

4. AddContextFiltersModal.tsx line 57 the ".includes()" if condition check always returns false because we add the ".md" extension inside the condition.

closes #256

