### PR TITLE
Create dir/notes on rightclick

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -35,6 +35,8 @@ import {
 } from "./Store/storeHandlers";
 import WindowsManager from "./windowManager";
 
+const fs = require('fs').promises;
+
 const store = new Store<StoreSchema>();
 // store.clear(); // clear store for testing
 const windowsManager = new WindowsManager();
@@ -167,8 +169,58 @@ ipcMain.handle("index-files-in-directory", async (event) => {
   }
 });
 
-ipcMain.handle("show-context-menu-file-item", (event, file) => {
+ipcMain.handle("show-context-menu-item", (event) => {
   const menu = new Menu();
+
+  menu.append(
+    new MenuItem({
+      label: "New Note",
+      click: () => {
+        event.sender.send("add-new-note-listener");
+      },
+    })
+  );
+
+  menu.append(
+    new MenuItem({
+      label: "New Directory",
+      click: () => {
+        event.sender.send("add-new-directory-listener");
+      },
+    })
+  );
+
+  const browserWindow = BrowserWindow.fromWebContents(event.sender);
+  if (browserWindow)
+    menu.popup({ window: browserWindow })
+});
+
+ipcMain.handle("show-context-menu-file-item", async (event, file) => {
+  const menu = new Menu();
+
+  const stats = await fs.stat(file.path);
+  const isDirectory = stats.isDirectory();
+
+  if (isDirectory) {
+    menu.append(
+      new MenuItem({
+        label: "New Note",
+        click: () => {
+          event.sender.send("add-new-note-listener", file.relativePath);
+        },
+      })
+    );
+
+    menu.append(
+      new MenuItem({
+        label: "New Directory",
+        click: () => {
+          event.sender.send("add-new-directory-listener", file.path);
+        },
+      })
+    );
+  }
+
   menu.append(
     new MenuItem({
       label: "Delete",

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,7 +1,4 @@
 import { IpcRendererEvent, contextBridge, ipcRenderer } from "electron";
-import { PromptWithRagResults } from "electron/main/database/dbSessionHandlers";
-import { BasePromptRequirements } from "electron/main/database/dbSessionHandlerTypes";
-import { DBEntry, DBQueryResult } from "electron/main/database/Schema";
 import {
   AugmentPromptWithFileProps,
   FileInfoNode,
@@ -15,9 +12,12 @@ import {
   EmbeddingModelWithLocalPath,
   EmbeddingModelWithRepo,
   HardwareConfig,
-  LLMGenerationParameters,
   LLMConfig,
+  LLMGenerationParameters,
 } from "electron/main/Store/storeConfig";
+import { DBEntry, DBQueryResult } from "electron/main/database/Schema";
+import { BasePromptRequirements } from "electron/main/database/dbSessionHandlerTypes";
+import { PromptWithRagResults } from "electron/main/database/dbSessionHandlers";
 
 import { ChatHistory } from "@/components/Chat/Chat";
 import { ChatHistoryMetadata } from "@/components/Chat/hooks/use-chat-history";
@@ -38,6 +38,9 @@ declare global {
     };
     contextMenu: {
       showFileItemContextMenu: (filePath: FileInfoNode) => void;
+    };
+    contextFileMenu: {
+      showMenuItemContext: () => void;
     };
     contextChatMenu: {
       showChatItemContext: (chatRow: ChatHistoryMetadata) => void;
@@ -333,6 +336,12 @@ contextBridge.exposeInMainWorld("ipcRenderer", {
 contextBridge.exposeInMainWorld("contextMenu", {
   showFileItemContextMenu: (file: FileInfoNode) => {
     ipcRenderer.invoke("show-context-menu-file-item", file);
+  },
+});
+
+contextBridge.exposeInMainWorld("contextFileMenu", {
+  showMenuItemContext: () => {
+    ipcRenderer.invoke("show-context-menu-item");
   },
 });
 

--- a/src/components/File/FileSideBar/FileItem.tsx
+++ b/src/components/File/FileSideBar/FileItem.tsx
@@ -78,12 +78,12 @@ export const FileItem: React.FC<FileInfoProps> = ({
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     window.contextMenu.showFileItemContextMenu(file);
   };
 
-  const itemClasses = `flex items-center cursor-pointer px-2 py-1 border-b border-gray-200 hover:bg-neutral-700 h-full mt-0 mb-0 ${
-    isSelected ? "bg-neutral-700 text-white font-semibold" : "text-gray-200"
-  } ${isDragOver ? "bg-neutral-500" : ""}`;
+  const itemClasses = `flex items-center cursor-pointer px-2 py-1 border-b border-gray-200 hover:bg-neutral-700 h-full mt-0 mb-0 ${isSelected ? "bg-neutral-700 text-white font-semibold" : "text-gray-200"
+    } ${isDragOver ? "bg-neutral-500" : ""}`;
 
   return (
     <div
@@ -106,9 +106,8 @@ export const FileItem: React.FC<FileInfoProps> = ({
           </span>
         )}
         <span
-          className={`text-[13px] flex-1 truncate mt-0 ${
-            isDirectory ? "font-semibold" : ""
-          }`}
+          className={`text-[13px] flex-1 truncate mt-0 ${isDirectory ? "font-semibold" : ""
+            }`}
         >
           {isDirectory ? file.name : removeFileExtension(file.name)}
         </span>

--- a/src/components/File/FileSideBar/index.tsx
+++ b/src/components/File/FileSideBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { CSSProperties, useEffect, useState } from "react";
 
 import { FileInfoNode, FileInfoTree } from "electron/main/Files/Types";
 import { FixedSizeList as List, ListChildComponentProps } from "react-window";
@@ -7,7 +7,8 @@ import RenameDirModal from "../RenameDirectory";
 import RenameNoteModal from "../RenameNote";
 
 import { FileItem } from "./FileItem";
-import { isFileNodeDirectory, moveFile } from "./fileOperations";
+import { isFileNodeDirectory } from "./fileOperations";
+
 
 interface FileListProps {
   files: FileInfoTree;
@@ -36,8 +37,13 @@ export const FileSidebar: React.FC<FileListProps> = ({
   setFileDirToBeRenamed,
   listHeight,
 }) => {
+
+
+
   return (
-    <div className="flex flex-col h-below-titlebar text-white overflow-y-auto overflow-x-hidden">
+    <div
+      className="flex flex-col h-below-titlebar text-white overflow-y-auto overflow-x-hidden"
+    >
       {noteToBeRenamed && (
         <RenameNoteModal
           isOpen={!!noteToBeRenamed}
@@ -138,16 +144,21 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
     return visibleItems;
   };
 
-  const handleDropOnBlank = async (e: React.DragEvent) => {
+  const handleMenuContext = (e: React.MouseEvent) => {
     e.preventDefault();
-    const sourcePath = e.dataTransfer.getData("text/plain");
-    const root = await window.electronStore.getVaultDirectoryForWindow();
-    try {
-      moveFile(sourcePath, root);
-    } catch (error) {
-      console.error("Failed to move file to root:", error);
-    }
+    window.contextFileMenu.showMenuItemContext();
+  }
+
+  const hideScrollbarStyle: CSSProperties = {
+    overflowY: 'auto',
+    scrollbarWidth: 'none',
   };
+
+  const webKitScrollBarStyles = `
+    div::-webkit-scrollbar {
+      display: none;
+    }
+  `;
 
   // Calculate visible items and item count
   const visibleItems = getVisibleFilesAndFlatten(files, expandedDirectories);
@@ -176,12 +187,14 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
 
   return (
     <div
-      onDrop={handleDropOnBlank}
-      onDragOver={(e) => e.preventDefault()}
-      style={{ height: listHeight, width: "100%", overflow: "hidden" }}
+      onContextMenu={handleMenuContext}
+      style={hideScrollbarStyle}
     >
+      <style>
+        {webKitScrollBarStyles}
+      </style>
       <List
-        height={listHeight - 30}
+        height={listHeight}
         itemCount={itemCount}
         itemSize={30}
         width={"100%"}
@@ -191,4 +204,5 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
       </List>
     </div>
   );
+
 };

--- a/src/components/File/NewNote.tsx
+++ b/src/components/File/NewNote.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { Button } from "@material-tailwind/react";
 import posthog from "posthog-js";
@@ -13,15 +13,24 @@ interface NewNoteComponentProps {
   isOpen: boolean;
   onClose: () => void;
   openRelativePath: (path: string) => void;
+  customFilePath: string;
 }
 
 const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
   isOpen,
   onClose,
   openRelativePath,
+  customFilePath,
 }) => {
   const [fileName, setFileName] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setFileName("");
+      setErrorMessage(null);
+    }
+  }, [isOpen]);
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newName = e.target.value;
@@ -42,8 +51,10 @@ const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
     if (!fileName || errorMessage) {
       return;
     }
-    openRelativePath(fileName);
-    posthog.capture("created_new_note_from_new_note_modal")
+    const pathPrefix = customFilePath ? customFilePath.replace(/\/?$/, '/') : '';
+    const fullPath = pathPrefix + fileName;
+    openRelativePath(fullPath);
+    posthog.capture("created_new_note_from_new_note_modal");
     onClose();
   };
 

--- a/src/components/Sidebars/IconsSidebar.tsx
+++ b/src/components/Sidebars/IconsSidebar.tsx
@@ -30,6 +30,8 @@ const IconsSidebar: React.FC<IconsSidebarProps> = ({
   const [isNewNoteModalOpen, setIsNewNoteModalOpen] = useState(false);
   const [isNewDirectoryModalOpen, setIsNewDirectoryModalOpen] = useState(false);
   const [isFlashcardModeOpen, setIsFlashcardModeOpen] = useState(false);
+  const [customDirectoryPath, setCustomDirectoryPath] = useState("");
+  const [customFilePath, setCustomFilePath] = useState("");
 
   const [initialFileToCreateFlashcard, setInitialFileToCreateFlashcard] =
     useState("");
@@ -49,6 +51,30 @@ const IconsSidebar: React.FC<IconsSidebarProps> = ({
     return () => {
       createFlashcardFileListener();
     };
+  }, []);
+
+  // open a new note window
+  useEffect(() => {
+    const handleNewNote = (relativePath: string) => {
+      setCustomFilePath(relativePath);
+      setIsNewNoteModalOpen(true);
+    }
+
+    window.ipcRenderer.receive("add-new-note-listener", (relativePath: string) => {
+      handleNewNote(relativePath);
+    })
+  }, []);
+
+  // open a new directory window
+  useEffect(() => {
+    const handleNewDirectory = (dirPath: string) => {
+      setCustomDirectoryPath(dirPath);
+      setIsNewDirectoryModalOpen(true);
+    }
+
+    window.ipcRenderer.receive("add-new-directory-listener", (dirPath) => {
+      handleNewDirectory(dirPath);
+    });
   }, []);
 
   return (
@@ -155,11 +181,12 @@ const IconsSidebar: React.FC<IconsSidebarProps> = ({
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
         openRelativePath={openRelativePath}
+        customFilePath={customFilePath}
       />
       <NewDirectoryComponent
         isOpen={isNewDirectoryModalOpen}
         onClose={() => setIsNewDirectoryModalOpen(false)}
-        onDirectoryCreate={() => console.log("Directory created")}
+        onDirectoryCreate={customDirectoryPath}
       />
       {isFlashcardModeOpen && (
         <FlashcardMenuModal


### PR DESCRIPTION
From #284 

Added ability to:

- Create new Note / Directores when rightclicking a directory
- New note / directoy is a child of this directory
- Right clicking empty file sidebar creates new context menu for creating file or directory


Possible Changes:

- Inside index.tsx, is there a way to check if this file is a directory or not without using node.js `fs`? Ideally each file object would create a field that states if this is a directory or not. 
