### PR TITLE
Refactor tab to work for both chat and file

### DIFF
--- a/electron/main/electron-store/ipcHandlers.ts
+++ b/electron/main/electron-store/ipcHandlers.ts
@@ -209,7 +209,7 @@ export const registerStoreHandlers = (store: Store<StoreSchema>, windowsManager:
   ipcMain.handle('add-current-open-files', (event, tab: Tab) => {
     if (tab === null) return
     const openTabs: Tab[] = store.get(StoreKeys.OpenTabs) || []
-    const existingTab = openTabs.findIndex((item) => item.filePath === tab.filePath)
+    const existingTab = openTabs.findIndex((item) => item.path === tab.path)
 
     /* If tab is already open, do not do anything */
     if (existingTab !== -1) return
@@ -246,7 +246,7 @@ export const registerStoreHandlers = (store: Store<StoreSchema>, windowsManager:
     if (!filePath) return
     const openTabs: Tab[] = store.get(StoreKeys.OpenTabs) || []
     // Filter out selected tab
-    const updatedTabs = openTabs.filter((tab) => tab.filePath !== filePath)
+    const updatedTabs = openTabs.filter((tab) => tab.path !== filePath)
     store.set(StoreKeys.OpenTabs, updatedTabs)
     event.sender.send('remove-tab-after-deletion', updatedTabs)
   })

--- a/electron/main/electron-store/storeConfig.ts
+++ b/electron/main/electron-store/storeConfig.ts
@@ -50,7 +50,7 @@ export type HardwareConfig = {
 
 export type Tab = {
   id: string // Unique ID for the tab, useful for operations
-  filePath: string // Path to the file open in the tab
+  path: string // Path to the content open in the tab
   title: string // Title of the tab
   lastAccessed: boolean
   // timeOpened: Date; // Timestamp to preserve order

--- a/src/components/Common/TitleBar.tsx
+++ b/src/components/Common/TitleBar.tsx
@@ -7,24 +7,22 @@ import { ModalProvider } from '../Providers/ModalProvider'
 export const titleBarHeight = '30px'
 
 interface TitleBarProps {
-  onFileSelect: (path: string) => void
-  currentFilePath: string | null // Used to create new open tabs when user clicks on new file to open
+  openTabContent: (path: string) => void
+  currentTab: string | null // Used to create new open tabs when user clicks on new file to open
   similarFilesOpen: boolean
   toggleSimilarFiles: () => void
   history: string[]
   setHistory: (string: string[]) => void
-  openFileAndOpenEditor: (path: string) => void
   openAbsolutePath: (path: string) => void
 }
 
 const TitleBar: React.FC<TitleBarProps> = ({
-  onFileSelect,
-  currentFilePath,
+  openTabContent,
+  currentTab,
   similarFilesOpen,
   toggleSimilarFiles,
   history,
   setHistory,
-  openFileAndOpenEditor,
   openAbsolutePath,
 }) => {
   const [platform, setPlatform] = useState('')
@@ -44,8 +42,8 @@ const TitleBar: React.FC<TitleBarProps> = ({
         <FileHistoryNavigator
           history={history}
           setHistory={setHistory}
-          onFileSelect={onFileSelect}
-          currentPath={currentFilePath || ''}
+          onFileSelect={openTabContent}
+          currentPath={currentTab || ''}
         />
       </div>
 
@@ -54,8 +52,8 @@ const TitleBar: React.FC<TitleBarProps> = ({
           <div className="flex whitespace-nowrap">
             <ModalProvider>
               <DraggableTabs
-                currentFilePath={currentFilePath || ''}
-                openFileAndOpenEditor={openFileAndOpenEditor}
+                currentTab={currentTab || ''}
+                openTabContent={openTabContent}
                 openAbsolutePath={openAbsolutePath}
               />
             </ModalProvider>

--- a/src/components/Common/TitleBar.tsx
+++ b/src/components/Common/TitleBar.tsx
@@ -14,7 +14,7 @@ interface TitleBarProps {
   history: string[]
   setHistory: (string: string[]) => void
   openAbsolutePath: (path: string) => void
-  setShowChatbot: (showChat: boolean) => void
+  openFileLayout: () => void
 }
 
 const TitleBar: React.FC<TitleBarProps> = ({
@@ -25,7 +25,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
   history,
   setHistory,
   openAbsolutePath,
-  setShowChatbot,
+  openFileLayout,
 }) => {
   const [platform, setPlatform] = useState('')
 
@@ -57,7 +57,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
                 currentTab={currentTab || ''}
                 openTabContent={openTabContent}
                 openAbsolutePath={openAbsolutePath}
-                setShowChatbot={setShowChatbot}
+                openFileLayout={openFileLayout}
               />
             </ModalProvider>
           </div>

--- a/src/components/Common/TitleBar.tsx
+++ b/src/components/Common/TitleBar.tsx
@@ -14,6 +14,7 @@ interface TitleBarProps {
   history: string[]
   setHistory: (string: string[]) => void
   openAbsolutePath: (path: string) => void
+  setShowChatbot: (showChat: boolean) => void
 }
 
 const TitleBar: React.FC<TitleBarProps> = ({
@@ -24,6 +25,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
   history,
   setHistory,
   openAbsolutePath,
+  setShowChatbot,
 }) => {
   const [platform, setPlatform] = useState('')
 
@@ -55,6 +57,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
                 currentTab={currentTab || ''}
                 openTabContent={openTabContent}
                 openAbsolutePath={openAbsolutePath}
+                setShowChatbot={setShowChatbot}
               />
             </ModalProvider>
           </div>

--- a/src/components/EmptyPage.tsx
+++ b/src/components/EmptyPage.tsx
@@ -6,10 +6,10 @@ import NewDirectoryComponent from './File/NewDirectory'
 
 interface EmptyPageProps {
   openAbsolutePath: (filePath: string, optionalContentToWriteOnCreate?: string) => Promise<void>
-  setShowChatbot: (showChat: boolean) => void
+  openFileLayout: () => void
 }
 
-const EmptyPage: React.FC<EmptyPageProps> = ({ openAbsolutePath, setShowChatbot }) => {
+const EmptyPage: React.FC<EmptyPageProps> = ({ openAbsolutePath, openFileLayout }) => {
   const { isNewNoteModalOpen, setIsNewNoteModalOpen, isNewDirectoryModalOpen, setIsNewDirectoryModalOpen } =
     useModalOpeners()
 
@@ -40,7 +40,7 @@ const EmptyPage: React.FC<EmptyPageProps> = ({ openAbsolutePath, setShowChatbot 
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
         openAbsolutePath={openAbsolutePath}
-        setShowChatbot={setShowChatbot}
+        openFileLayout={openFileLayout}
         currentOpenFilePath=""
       />
       <NewDirectoryComponent

--- a/src/components/EmptyPage.tsx
+++ b/src/components/EmptyPage.tsx
@@ -6,9 +6,10 @@ import NewDirectoryComponent from './File/NewDirectory'
 
 interface EmptyPageProps {
   openAbsolutePath: (filePath: string, optionalContentToWriteOnCreate?: string) => Promise<void>
+  setShowChatbot: (showChat: boolean) => void
 }
 
-const EmptyPage: React.FC<EmptyPageProps> = ({ openAbsolutePath }) => {
+const EmptyPage: React.FC<EmptyPageProps> = ({ openAbsolutePath, setShowChatbot }) => {
   const { isNewNoteModalOpen, setIsNewNoteModalOpen, isNewDirectoryModalOpen, setIsNewDirectoryModalOpen } =
     useModalOpeners()
 
@@ -39,6 +40,7 @@ const EmptyPage: React.FC<EmptyPageProps> = ({ openAbsolutePath }) => {
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
         openAbsolutePath={openAbsolutePath}
+        setShowChatbot={setShowChatbot}
         currentOpenFilePath=""
       />
       <NewDirectoryComponent

--- a/src/components/File/NewNote.tsx
+++ b/src/components/File/NewNote.tsx
@@ -12,6 +12,7 @@ interface NewNoteComponentProps {
   onClose: () => void
   openAbsolutePath: (path: string) => void
   currentOpenFilePath: string | null
+  setShowChatbot: (showChat: boolean) => void
 }
 
 const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
@@ -19,6 +20,7 @@ const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
   onClose,
   openAbsolutePath,
   currentOpenFilePath,
+  setShowChatbot,
 }) => {
   const [fileName, setFileName] = useState<string>('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -52,6 +54,7 @@ const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
       const directoryName = await window.path.dirname(currentOpenFilePath)
       finalPath = await window.path.join(directoryName, fileName)
     }
+    setShowChatbot(false)
     openAbsolutePath(finalPath)
     posthog.capture('created_new_note_from_new_note_modal')
     onClose()

--- a/src/components/File/NewNote.tsx
+++ b/src/components/File/NewNote.tsx
@@ -12,7 +12,7 @@ interface NewNoteComponentProps {
   onClose: () => void
   openAbsolutePath: (path: string) => void
   currentOpenFilePath: string | null
-  setShowChatbot: (showChat: boolean) => void
+  openFileLayout: () => void
 }
 
 const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
@@ -20,7 +20,7 @@ const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
   onClose,
   openAbsolutePath,
   currentOpenFilePath,
-  setShowChatbot,
+  openFileLayout,
 }) => {
   const [fileName, setFileName] = useState<string>('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -54,7 +54,7 @@ const NewNoteComponent: React.FC<NewNoteComponentProps> = ({
       const directoryName = await window.path.dirname(currentOpenFilePath)
       finalPath = await window.path.join(directoryName, fileName)
     }
-    setShowChatbot(false)
+    openFileLayout()
     openAbsolutePath(finalPath)
     posthog.capture('created_new_note_from_new_note_modal')
     onClose()

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -70,13 +70,23 @@ const MainPageComponent: React.FC = () => {
     setShowSimilarFiles(!showSimilarFiles)
   }
 
-  const openFileAndOpenEditor = async (path: string) => {
+  const openFileLayout = () => {
     setShowChatbot(false)
+    setSidebarShowing('files')
+  }
+
+  const openChatLayout = () => {
+    setShowChatbot(true)
+    setSidebarShowing('chats')
+  }
+
+  const openFileAndOpenEditor = async (path: string) => {
+    openFileLayout()
     openFileByPath(path)
   }
 
   const openChatAndOpenChat = (chatHistory: ChatHistory | undefined) => {
-    setShowChatbot(true)
+    openChatLayout()
     setCurrentChatHistory(chatHistory)
   }
 
@@ -173,7 +183,7 @@ const MainPageComponent: React.FC = () => {
           similarFilesOpen={showSimilarFiles} // This might need to be managed differently now
           toggleSimilarFiles={toggleSimilarFiles} // This might need to be managed differently now
           openAbsolutePath={openAbsolutePath}
-          setShowChatbot={setShowChatbot}
+          openFileLayout={openFileLayout}
         />
       </TabProvider>
 
@@ -185,7 +195,7 @@ const MainPageComponent: React.FC = () => {
           <ModalProvider>
             <IconsSidebar
               openAbsolutePath={openAbsolutePath}
-              setShowChatbot={setShowChatbot}
+              openFileLayout={openFileLayout}
               sidebarShowing={sidebarShowing}
               makeSidebarShow={setSidebarShowing}
               currentFilePath={filePath}
@@ -247,7 +257,7 @@ const MainPageComponent: React.FC = () => {
           !showChatbot && (
             <div className="relative flex size-full overflow-hidden">
               <ModalProvider>
-                <EmptyPage openAbsolutePath={openAbsolutePath} setShowChatbot={setShowChatbot} />
+                <EmptyPage openAbsolutePath={openAbsolutePath} openFileLayout={openFileLayout} />
               </ModalProvider>
             </div>
           )

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -18,6 +18,7 @@ import { ChatFilters, ChatHistory } from './Chat/chatUtils'
 import EmptyPage from './EmptyPage'
 import { TabProvider } from './Providers/TabProvider'
 import { ModalProvider } from './Providers/ModalProvider'
+import { isFilePath } from '../utils/strings'
 
 const MainPageComponent: React.FC = () => {
   const [showChatbot, setShowChatbot] = useState<boolean>(false)
@@ -74,14 +75,6 @@ const MainPageComponent: React.FC = () => {
   const openChatAndOpenChat = (chatHistory: ChatHistory | undefined) => {
     setShowChatbot(true)
     setCurrentChatHistory(chatHistory)
-  }
-
-  const isFilePath = (path: string) => {
-    const windowsPattern = /^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$/
-    const unixPattern = /^(\/[^/]+)+\/?$/
-    const macPattern = /^(\/[^/]+)+\/?$/
-
-    return windowsPattern.test(path) || unixPattern.test(path) || macPattern.test(path)
   }
 
   const openTabContent = async (path: string) => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -19,6 +19,8 @@ import EmptyPage from './EmptyPage'
 import { TabProvider } from './Providers/TabProvider'
 import { ModalProvider } from './Providers/ModalProvider'
 
+const UNINITIALIZED_STATE = 'UNINITIALIZED_STATE'
+
 const MainPageComponent: React.FC = () => {
   const [showChatbot, setShowChatbot] = useState<boolean>(false)
   const [showSimilarFiles, setShowSimilarFiles] = useState(true)
@@ -91,6 +93,7 @@ const MainPageComponent: React.FC = () => {
   }
 
   const getChatIdFromPath = (path: string) => {
+    if (chatHistoriesMetadata.length === 0) return UNINITIALIZED_STATE
     const metadata = chatHistoriesMetadata.find((chat) => chat.displayName === path)
     if (metadata) return metadata.id
     return ''
@@ -100,6 +103,7 @@ const MainPageComponent: React.FC = () => {
     if (!path) return
     const chatID = getChatIdFromPath(path)
     if (chatID) {
+      if (chatID === UNINITIALIZED_STATE) return
       const chat = await window.electronStore.getChatHistory(chatID)
       openChatAndOpenChat(chat)
     } else {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -49,15 +49,18 @@ const MainPageComponent: React.FC = () => {
   const { currentChatHistory, setCurrentChatHistory, chatHistoriesMetadata } = useChatHistory()
 
   useEffect(() => {
-    if (filePath && filePathRef.current !== filePath) {
+    if (filePath != null && filePathRef.current !== filePath) {
       filePathRef.current = filePath
       setCurrentTab(filePath)
     }
 
-    if (currentChatHistory && chatIDRef.current !== currentChatHistory.id) {
-      chatIDRef.current = currentChatHistory.id
-      const currentMetadata = chatHistoriesMetadata.find((chat) => chat.id === currentChatHistory.id)
-      if (currentMetadata) setCurrentTab(currentMetadata.displayName)
+    const currentChatHistoryId = currentChatHistory?.id ?? ''
+    if (chatIDRef.current !== currentChatHistoryId) {
+      chatIDRef.current = currentChatHistoryId
+      const currentMetadata = chatHistoriesMetadata.find((chat) => chat.id === currentChatHistoryId)
+      if (currentMetadata) {
+        setCurrentTab(currentMetadata.displayName)
+      }
     }
   }, [currentChatHistory, chatHistoriesMetadata, filePath])
 

--- a/src/components/Providers/TabProvider.tsx
+++ b/src/components/Providers/TabProvider.tsx
@@ -5,9 +5,9 @@ import { SidebarAbleToShow } from '../Sidebars/MainSidebar'
 
 interface TabProviderProps {
   children: ReactNode
-  openFileAndOpenEditor: (path: string) => void
+  openTabContent: (path: string) => void
   setFilePath: (path: string) => void
-  currentFilePath: string | null
+  currentTab: string | null
   sidebarShowing: string | null
   makeSidebarShow: (option: SidebarAbleToShow) => void
 }
@@ -35,9 +35,9 @@ export const useTabs = (): TabContextType => useContext(TabContext)
 
 export const TabProvider: React.FC<TabProviderProps> = ({
   children,
-  openFileAndOpenEditor,
+  openTabContent,
   setFilePath,
-  currentFilePath,
+  currentTab,
   sidebarShowing,
   makeSidebarShow,
 }) => {
@@ -74,7 +74,7 @@ export const TabProvider: React.FC<TabProviderProps> = ({
       const createTabObjectFromPath = (tabPath: string) => {
         return {
           id: uuidv4(),
-          filePath: tabPath,
+          path: tabPath,
           title: extractFileName(path),
           lastAccessed: true,
           // timeOpened: new Date(),
@@ -82,7 +82,7 @@ export const TabProvider: React.FC<TabProviderProps> = ({
         }
       }
 
-      const existingTab = openTabs.find((tab: Tab) => tab.filePath === path)
+      const existingTab = openTabs.find((tab: Tab) => tab.path === path)
       if (existingTab) return
       const tab = createTabObjectFromPath(path)
 
@@ -107,13 +107,13 @@ export const TabProvider: React.FC<TabProviderProps> = ({
         if (findIdx === -1) return prevTabs
 
         openTabs[findIdx].lastAccessed = false
-        closedFilePath = findIdx !== -1 ? prevTabs[findIdx].filePath : ''
+        closedFilePath = findIdx !== -1 ? prevTabs[findIdx].path : ''
         newIndex = findIdx > 0 ? findIdx - 1 : 1
 
-        if (closedFilePath === currentFilePath) {
+        if (closedFilePath === currentTab) {
           if (newIndex < openTabs.length) {
             openTabs[newIndex].lastAccessed = true
-            openFileAndOpenEditor(openTabs[newIndex].filePath)
+            openTabContent(openTabs[newIndex].path)
           }
           // Select the new index's file
           else setFilePath('')
@@ -126,7 +126,7 @@ export const TabProvider: React.FC<TabProviderProps> = ({
         window.electronStore.removeOpenTabs(tabId, findIdx, newIndex)
       }
     },
-    [currentFilePath, openFileAndOpenEditor, openTabs, setFilePath],
+    [currentTab, openTabContent, openTabs, setFilePath],
   )
 
   /* Updates tab order (on drag) and syncs it with backend */
@@ -152,9 +152,9 @@ export const TabProvider: React.FC<TabProviderProps> = ({
         return newTabs
       })
       if (sidebarShowing !== 'files') makeSidebarShow('files')
-      openFileAndOpenEditor(selectedTab.filePath)
+      openTabContent(selectedTab.path)
     },
-    [openFileAndOpenEditor, makeSidebarShow, sidebarShowing],
+    [openTabContent, makeSidebarShow, sidebarShowing],
   )
 
   const TabContextMemo = useMemo(

--- a/src/components/Providers/TabProvider.tsx
+++ b/src/components/Providers/TabProvider.tsx
@@ -1,7 +1,9 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react'
 import { v4 as uuidv4 } from 'uuid'
+
 import { Tab } from 'electron/main/electron-store/storeConfig'
 import { SidebarAbleToShow } from '../Sidebars/MainSidebar'
+import { isFilePath } from '../../utils/strings'
 
 interface TabProviderProps {
   children: ReactNode
@@ -151,7 +153,11 @@ export const TabProvider: React.FC<TabProviderProps> = ({
         window.electronStore.selectOpenTabs(newTabs)
         return newTabs
       })
-      if (sidebarShowing !== 'files') makeSidebarShow('files')
+
+      if (isFilePath(selectedTab.path)) {
+        if (sidebarShowing !== 'files') makeSidebarShow('files')
+      } else if (sidebarShowing !== 'chats') makeSidebarShow('chats')
+
       openTabContent(selectedTab.path)
     },
     [openTabContent, makeSidebarShow, sidebarShowing],

--- a/src/components/Providers/TabProvider.tsx
+++ b/src/components/Providers/TabProvider.tsx
@@ -120,15 +120,27 @@ export const TabProvider: React.FC<TabProviderProps> = ({
             openTabs[newIndex].lastAccessed = true
             openTabContent(openTabs[newIndex].path)
           }
-          // Select the new index's file
-          else if (getChatIdFromPath(closedPath)) {
-            setCurrentChatHistory(undefined)
-          } else {
-            setFilePath('')
-          }
         }
 
-        return prevTabs.filter((_, idx) => idx !== findIdx)
+        const nextTabs = prevTabs.filter((_, idx) => idx !== findIdx)
+
+        let fileTabCount = 0
+        let chatTabCount = 0
+        nextTabs.forEach((tab) => {
+          if (getChatIdFromPath(tab.path)) {
+            chatTabCount += 1
+          } else {
+            fileTabCount += 1
+          }
+        })
+        if (!fileTabCount) {
+          setFilePath('')
+        }
+        if (!chatTabCount) {
+          setCurrentChatHistory(undefined)
+        }
+
+        return nextTabs
       })
 
       if (newIndex !== -1 && findIdx !== -1) {

--- a/src/components/Sidebars/IconsSidebar.tsx
+++ b/src/components/Sidebars/IconsSidebar.tsx
@@ -20,6 +20,7 @@ interface IconsSidebarProps {
   sidebarShowing: SidebarAbleToShow
   makeSidebarShow: (show: SidebarAbleToShow) => void
   currentFilePath: string | null
+  setShowChatbot: (showChat: boolean) => void
 }
 
 const IconsSidebar: React.FC<IconsSidebarProps> = ({
@@ -27,6 +28,7 @@ const IconsSidebar: React.FC<IconsSidebarProps> = ({
   sidebarShowing,
   makeSidebarShow,
   currentFilePath,
+  setShowChatbot,
 }) => {
   const [initialFileToCreateFlashcard, setInitialFileToCreateFlashcard] = useState('')
   const [initialFileToReviewFlashcard, setInitialFileToReviewFlashcard] = useState('')
@@ -127,6 +129,7 @@ const IconsSidebar: React.FC<IconsSidebarProps> = ({
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
         openAbsolutePath={openAbsolutePath}
+        setShowChatbot={setShowChatbot}
         currentOpenFilePath={currentFilePath}
       />
       <NewDirectoryComponent

--- a/src/components/Sidebars/IconsSidebar.tsx
+++ b/src/components/Sidebars/IconsSidebar.tsx
@@ -20,7 +20,7 @@ interface IconsSidebarProps {
   sidebarShowing: SidebarAbleToShow
   makeSidebarShow: (show: SidebarAbleToShow) => void
   currentFilePath: string | null
-  setShowChatbot: (showChat: boolean) => void
+  openFileLayout: () => void
 }
 
 const IconsSidebar: React.FC<IconsSidebarProps> = ({
@@ -28,7 +28,7 @@ const IconsSidebar: React.FC<IconsSidebarProps> = ({
   sidebarShowing,
   makeSidebarShow,
   currentFilePath,
-  setShowChatbot,
+  openFileLayout,
 }) => {
   const [initialFileToCreateFlashcard, setInitialFileToCreateFlashcard] = useState('')
   const [initialFileToReviewFlashcard, setInitialFileToReviewFlashcard] = useState('')
@@ -129,7 +129,7 @@ const IconsSidebar: React.FC<IconsSidebarProps> = ({
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
         openAbsolutePath={openAbsolutePath}
-        setShowChatbot={setShowChatbot}
+        openFileLayout={openFileLayout}
         currentOpenFilePath={currentFilePath}
       />
       <NewDirectoryComponent

--- a/src/components/Tabs/TabBar.tsx
+++ b/src/components/Tabs/TabBar.tsx
@@ -12,7 +12,7 @@ interface DraggableTabsProps {
   currentTab: string
   openTabContent: (path: string) => void
   openAbsolutePath: (path: string) => void
-  setShowChatbot: (showChat: boolean) => void
+  openFileLayout: () => void
 }
 
 interface TooltipProps {
@@ -52,7 +52,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({
   currentTab,
   openTabContent,
   openAbsolutePath,
-  setShowChatbot,
+  openFileLayout,
 }) => {
   const { openTabs, addTab, selectTab, removeTabByID, updateTabOrder } = useTabs()
   const [isLastTabAccessed, setIsLastTabAccessed] = useState<boolean>(false)
@@ -192,7 +192,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
         openAbsolutePath={openAbsolutePath}
-        setShowChatbot={setShowChatbot}
+        openFileLayout={openFileLayout}
         currentOpenFilePath={currentTab}
       />
     </div>

--- a/src/components/Tabs/TabBar.tsx
+++ b/src/components/Tabs/TabBar.tsx
@@ -9,8 +9,8 @@ import NewNoteComponent from '../File/NewNote'
 import { useModalOpeners } from '../Providers/ModalProvider'
 
 interface DraggableTabsProps {
-  currentFilePath: string
-  openFileAndOpenEditor: (path: string) => void
+  currentTab: string
+  openTabContent: (path: string) => void
   openAbsolutePath: (path: string) => void
 }
 
@@ -47,7 +47,7 @@ const Tooltip: React.FC<TooltipProps> = ({ filepath, position }) => {
   )
 }
 
-const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentFilePath, openFileAndOpenEditor, openAbsolutePath }) => {
+const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentTab, openTabContent, openAbsolutePath }) => {
   const { openTabs, addTab, selectTab, removeTabByID, updateTabOrder } = useTabs()
   const [isLastTabAccessed, setIsLastTabAccessed] = useState<boolean>(false)
 
@@ -62,9 +62,9 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentFilePath, openFile
   // we are using it inside a useContext we can remove it
   /* eslint-disable */
   useEffect(() => {
-    if (!currentFilePath) return
-    addTab(currentFilePath)
-  }, [currentFilePath])
+    if (!currentTab) return
+    addTab(currentTab)
+  }, [currentTab])
   /* eslint-enable */
 
   /*
@@ -76,7 +76,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentFilePath, openFile
         openTabs.forEach((tab: Tab) => {
           if (tab.lastAccessed) {
             setIsLastTabAccessed(true)
-            openFileAndOpenEditor(tab.filePath)
+            openTabContent(tab.path)
             return true
           }
           return false
@@ -85,7 +85,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentFilePath, openFile
     }
 
     selectLastTabAccessed()
-  }, [openTabs, openFileAndOpenEditor, isLastTabAccessed])
+  }, [openTabs, openTabContent, isLastTabAccessed])
 
   const onDragStart = (event: any, tabId: string) => {
     event.dataTransfer.setData('tabId', tabId)
@@ -116,7 +116,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentFilePath, openFile
 
   const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement, MouseEvent>, tab: Tab) => {
     const rect = e.currentTarget.getBoundingClientRect() || null
-    setHoveredTab(tab.filePath)
+    setHoveredTab(tab.path)
     setTooltipPosition({
       x: rect.left - 75,
       y: rect.bottom - 5,
@@ -155,7 +155,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentFilePath, openFile
                 onDrop={onDrop}
                 onDragOver={onDragOver}
                 className={`relative flex w-full cursor-pointer items-center justify-between gap-1 rounded-md p-2 text-sm text-white
-                ${currentFilePath === tab.filePath ? 'bg-dark-gray-c-eleven' : ''}`}
+                ${currentTab === tab.path ? 'bg-dark-gray-c-eleven' : ''}`}
                 onClick={() => handleTabSelect(tab)}
               >
                 <span className="truncate">{removeFileExtension(tab.title)}</span>
@@ -168,7 +168,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentFilePath, openFile
                 >
                   &times;
                 </span>
-                {hoveredTab === tab.filePath && <Tooltip filepath={tab.filePath} position={tooltipPosition} />}
+                {hoveredTab === tab.path && <Tooltip filepath={tab.path} position={tooltipPosition} />}
               </div>
             </div>
           ))}
@@ -186,7 +186,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentFilePath, openFile
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
         openAbsolutePath={openAbsolutePath}
-        currentOpenFilePath={currentFilePath}
+        currentOpenFilePath={currentTab}
       />
     </div>
   )

--- a/src/components/Tabs/TabBar.tsx
+++ b/src/components/Tabs/TabBar.tsx
@@ -12,6 +12,7 @@ interface DraggableTabsProps {
   currentTab: string
   openTabContent: (path: string) => void
   openAbsolutePath: (path: string) => void
+  setShowChatbot: (showChat: boolean) => void
 }
 
 interface TooltipProps {
@@ -47,7 +48,12 @@ const Tooltip: React.FC<TooltipProps> = ({ filepath, position }) => {
   )
 }
 
-const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentTab, openTabContent, openAbsolutePath }) => {
+const DraggableTabs: React.FC<DraggableTabsProps> = ({
+  currentTab,
+  openTabContent,
+  openAbsolutePath,
+  setShowChatbot,
+}) => {
   const { openTabs, addTab, selectTab, removeTabByID, updateTabOrder } = useTabs()
   const [isLastTabAccessed, setIsLastTabAccessed] = useState<boolean>(false)
 
@@ -186,6 +192,7 @@ const DraggableTabs: React.FC<DraggableTabsProps> = ({ currentTab, openTabConten
         isOpen={isNewNoteModalOpen}
         onClose={() => setIsNewNoteModalOpen(false)}
         openAbsolutePath={openAbsolutePath}
+        setShowChatbot={setShowChatbot}
         currentOpenFilePath={currentTab}
       />
     </div>

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -51,11 +51,3 @@ export const getInvalidCharacterInFileName = async (filename: string): Promise<s
 
   return idx === -1 ? null : filename[idx]
 }
-
-export const isFilePath = (path: string) => {
-  const windowsPattern = /^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$/
-  const unixPattern = /^(\/[^/]+)+\/?$/
-  const macPattern = /^(\/[^/]+)+\/?$/
-
-  return windowsPattern.test(path) || unixPattern.test(path) || macPattern.test(path)
-}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -51,3 +51,11 @@ export const getInvalidCharacterInFileName = async (filename: string): Promise<s
 
   return idx === -1 ? null : filename[idx]
 }
+
+export const isFilePath = (path: string) => {
+  const windowsPattern = /^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$/
+  const unixPattern = /^(\/[^/]+)+\/?$/
+  const macPattern = /^(\/[^/]+)+\/?$/
+
+  return windowsPattern.test(path) || unixPattern.test(path) || macPattern.test(path)
+}


### PR DESCRIPTION
fix #352
/claim #352

This is a major refactor on how tabs work in app. Tabs now are decoupled from file path and can be either a file path and chat path. 

Some of the highlights from this implementations:
- tab can be file/chat;
- when a file tab is opened, file sidebar is also opened; when a chat tab is opened, chat sidebar is opened;
- when file/chat tabs are closed, their selected state is sidebar is also updated


https://github.com/user-attachments/assets/cabb9b79-bc7d-4891-8f78-15b102995f99

 