### PR TITLE
Fixed bottom note bug.

### DIFF
--- a/src/components/Sidebars/FileSideBar/index.tsx
+++ b/src/components/Sidebars/FileSideBar/index.tsx
@@ -51,11 +51,11 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
   handleDirectoryToggle,
   lheight,
 }) => {
-  const [listHeight, setListHeight] = useState(lheight ?? window.innerHeight)
+  const [listHeight, setListHeight] = useState(lheight ?? window.innerHeight - 50)
 
   useEffect(() => {
     const updateHeight = () => {
-      setListHeight(lheight ?? window.innerHeight)
+      setListHeight(lheight ?? window.innerHeight - 50)
     }
     window.addEventListener('resize', updateHeight)
     return () => {


### PR DESCRIPTION
Closes #365.

Originally calculated height of sidebar by window.innerHeight, but never subtracted the height of the titlebar. Since it's fixed, we can just hardcode its height.