### PR TITLE
Always show highlight buttons

### DIFF
--- a/src/components/Editor/HighlightExtension.tsx
+++ b/src/components/Editor/HighlightExtension.tsx
@@ -24,10 +24,8 @@ const HighlightExtension = (setHighlightData: (data: HighlightData) => void) =>
                   const { top, left, right } = editorView.coordsAtPos(to)
 
                   // Calculate the button position below the last word
-                  const buttonTop = top - 35 // Adjust the vertical offset as needed
+                  const buttonTop = top >= window.innerHeight ? 20 : top - 35 // Adjust the vertical offset as needed
                   const buttonLeft = (left + right) / 2 - 190 // Position the button horizontally centered
-
-                  console.log('calling sethighlight data: ', highlightedText)
                   setHighlightData({
                     text: highlightedText,
                     position: { top: buttonTop, left: buttonLeft },


### PR DESCRIPTION
fix https://github.com/reorproject/reor/issues/348
/claim https://github.com/reorproject/reor/issues/348


I think it might be a product decision to show the highlight utility button when texts overflows, personally I think it would be better to display at the top but open for discussion

https://github.com/user-attachments/assets/65702027-fd01-4655-9772-cae98afde796

