### PR TITLE
chore: rename ollama exec file for linux

### DIFF
--- a/electron/main/llm/models/ollama.ts
+++ b/electron/main/llm/models/ollama.ts
@@ -92,7 +92,7 @@ class OllamaService {
           : path.join(app.getAppPath(), 'binaries', 'darwin')
         break
       case 'linux':
-        exeName = 'ollama-linux-amd64'
+        exeName = 'ollama'
         exeDir = app.isPackaged
           ? path.join(process.resourcesPath, 'binaries')
           : path.join(app.getAppPath(), 'binaries', 'linux')


### PR DESCRIPTION
fixes #428