### PR TITLE
Fix: embedding models not showing in the dropdown

### DIFF
--- a/src/components/Settings/EmbeddingSettings/EmbeddingModelSelect.tsx
+++ b/src/components/Settings/EmbeddingSettings/EmbeddingModelSelect.tsx
@@ -22,8 +22,8 @@ const EmbeddingModelSelect: React.FC<EmbeddingModelSelectProps> = ({
         {Object.entries(embeddingModels).map(([model, config]) => (
           <SelectItem key={model} value={model}>
             <div>
-              <div>{config.readableName}</div>
-              <div className="text-xs text-gray-400">{config.description}</div>
+              <div>{model}</div>
+              <div className="text-xs text-gray-400">{config.type}</div>
             </div>
           </SelectItem>
         ))}

--- a/src/components/Settings/EmbeddingSettings/EmbeddingModelSelect.tsx
+++ b/src/components/Settings/EmbeddingSettings/EmbeddingModelSelect.tsx
@@ -22,8 +22,8 @@ const EmbeddingModelSelect: React.FC<EmbeddingModelSelectProps> = ({
         {Object.entries(embeddingModels).map(([model, config]) => (
           <SelectItem key={model} value={model}>
             <div>
-              <div>{model}</div>
-              <div className="text-xs text-gray-400">{config.type}</div>
+              <div>{config.readableName || model}</div>
+              <div className="text-xs text-gray-400">{config.description}</div>
             </div>
           </SelectItem>
         ))}


### PR DESCRIPTION
Fallback for embeddings that don't have `readableName` and `description` attributes.

Before:
<img width="472" alt="image" src="https://github.com/user-attachments/assets/18aefb59-88fd-41b9-831e-a7b28db82994">

After:
<img width="263" alt="image" src="https://github.com/user-attachments/assets/97614dec-a4cc-4071-95c3-7d618721a783">

