### PR TITLE
fix: prevent writing assistant's trigger from being invisible

### DIFF
--- a/src/components/WritingAssistant/WritingAssistant.tsx
+++ b/src/components/WritingAssistant/WritingAssistant.tsx
@@ -388,8 +388,8 @@ const WritingAssistant: React.FC = () => {
         <Popover>
           <PopoverTrigger
             style={{
-              top: `${highlightData.position.top}px`,
-              left: `${highlightData.position.left + 30}px`,
+              top: `${Math.max(highlightData.position.top + 30, 10)}px`,
+              left: `${Math.min(highlightData.position.left, window.innerWidth - 550)}px`,
               zIndex: 50,
             }}
             className="absolute flex size-7 cursor-pointer items-center justify-center rounded-full border-none bg-gray-200 text-gray-600 shadow-md hover:bg-gray-300"
@@ -404,7 +404,7 @@ const WritingAssistant: React.FC = () => {
               ref={optionsContainerRef}
               style={{
                 position: 'absolute',
-                transform: 'translate(-50%, -50%)',
+                transform: 'translate(-50%, -40%)',
               }}
               className="absolute z-50 w-96 rounded-md border border-gray-300 bg-white p-2.5"
             >


### PR DESCRIPTION
Fix the below scenarios, the trigger becomes invisible

<img width="867" alt="image" src="https://github.com/user-attachments/assets/d7fdaa21-f3af-479c-bc34-093b830e0628">
<img width="870" alt="image" src="https://github.com/user-attachments/assets/ba61a9c2-14ef-43df-b8e2-791d6ad406e2">
